### PR TITLE
fix: unify deviceId to vault-scoped storage preventing cross-vault contamination

### DIFF
--- a/src/crypto/VaultMarker.ts
+++ b/src/crypto/VaultMarker.ts
@@ -6,6 +6,7 @@
  * sync with wrong passphrase.
  */
 
+import { App } from 'obsidian';
 import { S3Provider } from '../storage/S3Provider';
 import { VaultEncryptionMarker } from '../types';
 import { deriveKey, bytesToBase64, base64ToBytes, generateSalt } from './KeyDerivation';
@@ -148,7 +149,28 @@ export class VaultMarker {
 }
 
 /**
- * Generate a unique device ID
+ * Vault-scoped local storage key for the device ID.
+ *
+ * This is the single canonical key used by both the sync engine and
+ * backup/encryption subsystems.  Obsidian's {@link App.loadLocalStorage}
+ * and {@link App.saveLocalStorage} automatically namespace the key
+ * per-vault, so two vaults on the same device receive independent IDs.
+ */
+const DEVICE_ID_STORAGE_KEY = 's3-sync-device-id';
+
+/**
+ * Legacy global localStorage key used by versions prior to the
+ * vault-scoped migration.  Checked once during migration so existing
+ * users keep the same device ID in their first vault after the upgrade.
+ */
+const LEGACY_GLOBAL_STORAGE_KEY = 'obsidian-s3-sync-device-id';
+
+/**
+ * Generate a unique device ID using cryptographically random bytes.
+ *
+ * Format: `device-<16 hex chars>` (8 random bytes).
+ *
+ * @returns A new device ID string
  */
 export function generateDeviceId(): string {
     const random = new Uint8Array(8);
@@ -160,22 +182,43 @@ export function generateDeviceId(): string {
 }
 
 /**
- * Get or create device ID
- * Uses a simple random ID - note: localStorage is used here as this is
- * for device identification, not vault-specific data
+ * Get or create a vault-scoped device ID.
+ *
+ * Uses Obsidian's vault-scoped storage ({@link App.loadLocalStorage} /
+ * {@link App.saveLocalStorage}) so each vault on the same machine gets
+ * its own device ID.  This prevents cross-vault contamination when a
+ * single user runs multiple vaults.
+ *
+ * **Migration**: On first call after upgrade, if vault-scoped storage is
+ * empty the function checks the legacy global `window.localStorage` key
+ * (`obsidian-s3-sync-device-id`) and adopts that value for this vault.
+ * The global key is intentionally left intact so other vaults (not yet
+ * upgraded) can also migrate independently.
+ *
+ * @param app - The Obsidian {@link App} instance (provides vault-scoped storage)
+ * @returns The device ID for this vault
  */
-export function getOrCreateDeviceId(): string {
-    const STORAGE_KEY = 'obsidian-s3-sync-device-id';
-
-    // Try to get existing device ID from window localStorage
-    // Note: Using window.localStorage directly as this is device-specific, not vault-specific
-    let deviceId = window.localStorage.getItem(STORAGE_KEY);
-
-    if (!deviceId) {
-        // Generate new device ID
-        deviceId = generateDeviceId();
-        window.localStorage.setItem(STORAGE_KEY, deviceId);
+export function getOrCreateDeviceId(app: App): string {
+    // 1. Try vault-scoped storage first
+    const existing = app.loadLocalStorage(DEVICE_ID_STORAGE_KEY) as string | null;
+    if (existing) {
+        return existing;
     }
 
+    // 2. Migrate from legacy global localStorage if available
+    let deviceId: string | null = null;
+    try {
+        deviceId = window.localStorage.getItem(LEGACY_GLOBAL_STORAGE_KEY);
+    } catch {
+        // window.localStorage may not be available in all environments
+    }
+
+    // 3. Generate a fresh ID if no legacy value exists
+    if (!deviceId) {
+        deviceId = generateDeviceId();
+    }
+
+    // 4. Persist into vault-scoped storage
+    app.saveLocalStorage(DEVICE_ID_STORAGE_KEY, deviceId);
     return deviceId;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,8 +77,7 @@ export default class S3SyncBackupPlugin extends Plugin {
 		// Load settings
 		await this.loadSettings();
 
-		// Get device ID
-		this.deviceId = getOrCreateDeviceId();
+		this.deviceId = getOrCreateDeviceId(this.app);
 
 		// Initialize S3 provider
 		this.s3Provider = new S3Provider(this.settings);
@@ -109,7 +108,8 @@ export default class S3SyncBackupPlugin extends Plugin {
 			this.s3Provider,
 			this.syncJournal,
 			this.changeTracker,
-			this.settings
+			this.settings,
+			this.deviceId
 		);
 
 		// Initialize sync scheduler

--- a/src/sync/SyncEngine.ts
+++ b/src/sync/SyncEngine.ts
@@ -121,12 +121,11 @@ export class SyncEngine {
         private s3Provider: S3Provider,
         private journal: SyncJournal,
         private changeTracker: ChangeTracker,
-        private settings: S3SyncBackupSettings
+        private settings: S3SyncBackupSettings,
+        deviceId: string
     ) {
         this.debugLogging = settings.debugLogging;
-        this.deviceId = this.getOrCreateStoredString('s3-sync-device-id', () => (
-            `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`
-        ));
+        this.deviceId = deviceId;
         this.deviceCreatedAt = Number(this.getOrCreateStoredString('s3-sync-device-created-at', () => String(Date.now())));
         this.normalizedSyncPrefix = normalizePrefix(settings.syncPrefix);
         this.remoteStore = new RemoteSyncStore(this.s3Provider, this.normalizedSyncPrefix);
@@ -924,7 +923,7 @@ export class SyncEngine {
         const navigatorAgent = globalThis.navigator?.userAgent || 'Unknown platform';
         const deviceInfo: RemoteSyncDeviceInfo = {
             deviceId: this.deviceId,
-            deviceName: navigatorAgent.split(' ')[0] || 'Obsidian',
+            deviceName: this.app.vault.getName(),
             platform: navigatorAgent,
             lastSeenAt: Date.now(),
             createdAt: this.deviceCreatedAt,

--- a/tests/crypto/VaultMarker.test.ts
+++ b/tests/crypto/VaultMarker.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { App } from 'obsidian';
+import { generateDeviceId, getOrCreateDeviceId } from '../../src/crypto/VaultMarker';
+
+describe('generateDeviceId', () => {
+	it('returns a string with "device-" prefix and 16 hex characters', () => {
+		const id = generateDeviceId();
+		expect(id).toMatch(/^device-[0-9a-f]{16}$/);
+	});
+
+	it('generates unique IDs on successive calls', () => {
+		const ids = new Set(Array.from({ length: 20 }, () => generateDeviceId()));
+		expect(ids.size).toBe(20);
+	});
+});
+
+describe('getOrCreateDeviceId', () => {
+	let mockApp: App;
+	let vaultStorage: Map<string, string>;
+
+	beforeEach(() => {
+		vaultStorage = new Map();
+
+		mockApp = {
+			loadLocalStorage: jest.fn((key: string) => vaultStorage.get(key) ?? null),
+			saveLocalStorage: jest.fn((key: string, value: string) => {
+				vaultStorage.set(key, value);
+			}),
+		} as unknown as App;
+
+		window.localStorage.removeItem('obsidian-s3-sync-device-id');
+	});
+
+	afterEach(() => {
+		window.localStorage.removeItem('obsidian-s3-sync-device-id');
+	});
+
+	it('generates a new device ID when no prior value exists', () => {
+		const id = getOrCreateDeviceId(mockApp);
+
+		expect(id).toMatch(/^device-[0-9a-f]{16}$/);
+		expect(mockApp.saveLocalStorage).toHaveBeenCalledWith('s3-sync-device-id', id);
+	});
+
+	it('returns the existing vault-scoped ID without regenerating', () => {
+		vaultStorage.set('s3-sync-device-id', 'device-existing1234abcd');
+
+		const id = getOrCreateDeviceId(mockApp);
+
+		expect(id).toBe('device-existing1234abcd');
+		expect(mockApp.saveLocalStorage).not.toHaveBeenCalled();
+	});
+
+	it('migrates a legacy global localStorage ID into vault-scoped storage', () => {
+		window.localStorage.setItem('obsidian-s3-sync-device-id', 'device-legacy00112233');
+
+		const id = getOrCreateDeviceId(mockApp);
+
+		expect(id).toBe('device-legacy00112233');
+		expect(mockApp.saveLocalStorage).toHaveBeenCalledWith('s3-sync-device-id', 'device-legacy00112233');
+	});
+
+	it('does not migrate when vault-scoped storage already has a value', () => {
+		window.localStorage.setItem('obsidian-s3-sync-device-id', 'device-legacy00112233');
+		vaultStorage.set('s3-sync-device-id', 'device-vaultspecific99');
+
+		const id = getOrCreateDeviceId(mockApp);
+
+		expect(id).toBe('device-vaultspecific99');
+		expect(mockApp.saveLocalStorage).not.toHaveBeenCalled();
+	});
+
+	it('leaves the legacy global key intact after migration', () => {
+		window.localStorage.setItem('obsidian-s3-sync-device-id', 'device-legacy00112233');
+
+		getOrCreateDeviceId(mockApp);
+
+		expect(window.localStorage.getItem('obsidian-s3-sync-device-id')).toBe('device-legacy00112233');
+	});
+
+	it('produces distinct IDs for two different vaults (vault-scoped isolation)', () => {
+		const vault1Storage = new Map<string, string>();
+		const vault2Storage = new Map<string, string>();
+
+		const app1 = {
+			loadLocalStorage: jest.fn((key: string) => vault1Storage.get(key) ?? null),
+			saveLocalStorage: jest.fn((key: string, value: string) => {
+				vault1Storage.set(key, value);
+			}),
+		} as unknown as App;
+
+		const app2 = {
+			loadLocalStorage: jest.fn((key: string) => vault2Storage.get(key) ?? null),
+			saveLocalStorage: jest.fn((key: string, value: string) => {
+				vault2Storage.set(key, value);
+			}),
+		} as unknown as App;
+
+		const id1 = getOrCreateDeviceId(app1);
+		const id2 = getOrCreateDeviceId(app2);
+
+		expect(id1).not.toBe(id2);
+		expect(vault1Storage.get('s3-sync-device-id')).toBe(id1);
+		expect(vault2Storage.get('s3-sync-device-id')).toBe(id2);
+	});
+
+	it('handles window.localStorage being unavailable gracefully', () => {
+		const originalLocalStorage = window.localStorage;
+		Object.defineProperty(window, 'localStorage', {
+			get: () => { throw new Error('SecurityError: localStorage not available'); },
+			configurable: true,
+		});
+
+		const id = getOrCreateDeviceId(mockApp);
+
+		expect(id).toMatch(/^device-[0-9a-f]{16}$/);
+		expect(mockApp.saveLocalStorage).toHaveBeenCalledWith('s3-sync-device-id', id);
+
+		Object.defineProperty(window, 'localStorage', {
+			get: () => originalLocalStorage,
+			configurable: true,
+		});
+	});
+
+	it('returns the same ID on repeated calls for the same vault', () => {
+		const first = getOrCreateDeviceId(mockApp);
+		const second = getOrCreateDeviceId(mockApp);
+
+		expect(first).toBe(second);
+	});
+});

--- a/tests/sync/SyncEngine.test.ts
+++ b/tests/sync/SyncEngine.test.ts
@@ -114,6 +114,7 @@ function createEngine(): SyncEngine {
 		saveLocalStorage: jest.fn(),
 		vault: {
 			getFiles: jest.fn().mockReturnValue([]),
+			getName: jest.fn().mockReturnValue('TestVault'),
 		},
 	} as unknown as App;
 
@@ -134,7 +135,8 @@ function createEngine(): SyncEngine {
 		mockS3Provider as never,
 		mockJournal,
 		mockChangeTracker,
-		createSettings()
+		createSettings(),
+		'test-device-id'
 	);
 }
 


### PR DESCRIPTION
Previously two separate deviceId systems existed: VaultMarker used global window.localStorage (shared across vaults) while SyncEngine used Obsidian's vault-scoped app.loadLocalStorage (per-vault). This caused backup manifests and encryption markers to share the same deviceId across multiple vaults on the same device.

Changes:
- Refactor getOrCreateDeviceId() to use vault-scoped app storage
- Add migration from legacy global localStorage key on first use
- SyncEngine now receives deviceId via constructor (single source)
- touchRemoteDevice uses vault name for deviceName instead of userAgent
- Add 10 new tests for deviceId generation, migration, and isolation