### PR TITLE
fix(manifest): rename plugin id to pass new community store validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 **Obsidian S3 Sync & Backup** — An Obsidian community plugin that provides bi-directional vault synchronization and scheduled backups for S3-compatible storage (AWS S3, Cloudflare R2, RustFS) with optional end-to-end encryption.
 
-**Plugin ID:** `s3-sync-and-backup`
+**Plugin ID:** `simple-storage-sync-and-backup`
 
 | Attribute | Value |
 |-----------|-------|
@@ -169,7 +169,7 @@ Uses `eslint-plugin-obsidianmd`:
 ### Manual Testing
 
 1. Run `npm run build`
-2. Copy `main.js`, `manifest.json`, `styles.css` to: `<Vault>/.obsidian/plugins/s3-sync-and-backup/`
+2. Copy `main.js`, `manifest.json`, `styles.css` to: `<Vault>/.obsidian/plugins/simple-storage-sync-and-backup/`
 3. Reload Obsidian and enable in **Settings → Community plugins**
 
 ## Documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ To test your changes in a live Obsidian instance:
 1.  Create a test vault in Obsidian (or use an existing one).
 2.  Create the plugin folder:
     ```
-    <VaultPath>/.obsidian/plugins/s3-sync-and-backup/
+    <VaultPath>/.obsidian/plugins/simple-storage-sync-and-backup/
     ```
 3.  Build the plugin: `npm run build`
 4.  Copy `main.js`, `manifest.json`, and `styles.css` into the plugin folder.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Vault synchronization and scheduled backups across devices using S3-compatible s
 
 ### Manual Installation
 1. Download `main.js`, `manifest.json`, and `styles.css` from the [latest release](https://github.com/ceilaolabs/obsidian-s3-sync-and-backup/releases).
-2. Create the folder: `<VaultPath>/.obsidian/plugins/s3-sync-and-backup/`
+2. Create the folder: `<VaultPath>/.obsidian/plugins/simple-storage-sync-and-backup/`
 3. Copy the downloaded files into this folder.
 4. Reload Obsidian and enable the plugin in **Settings** → **Community plugins**.
 
@@ -191,7 +191,7 @@ your-bucket/
     └── backup-2024-12-24T14-30-00/
 ```
 
-> **Note:** The plugin's own settings directory (`.obsidian/plugins/s3-sync-and-backup/`) is never uploaded to S3, regardless of exclude pattern configuration.
+> **Note:** The plugin's own settings directory (`.obsidian/plugins/simple-storage-sync-and-backup/`) is never uploaded to S3, regardless of exclude pattern configuration.
 
 ---
 
@@ -250,7 +250,7 @@ Yes, but existing files under the old prefix won't be moved. The plugin will tre
 
 <details>
 <summary><strong>What files are excluded from sync?</strong></summary>
-By default, <code>**/workspace*</code> and <code>.trash/**</code> are excluded. You can customize this in <strong>Settings → Advanced → Exclude patterns</strong>. The plugin's own settings directory (<code>.obsidian/plugins/s3-sync-and-backup/</code>) is always excluded and cannot be overridden.
+By default, <code>**/workspace*</code> and <code>.trash/**</code> are excluded. You can customize this in <strong>Settings → Advanced → Exclude patterns</strong>. The plugin's own settings directory (<code>.obsidian/plugins/simple-storage-sync-and-backup/</code>) is always excluded and cannot be overridden.
 </details>
 
 ---

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-	"id": "s3-sync-and-backup",
+	"id": "simple-storage-sync-and-backup",
 	"name": "S3 Sync & Backup",
 	"version": "3.4.0",
 	"minAppVersion": "1.0.0",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -134,7 +134,7 @@ export function registerCommands(plugin: S3SyncBackupPlugin): void {
         callback: () => {
             // Open settings to backup section
             (plugin.app as unknown as { setting: { open: () => void; openTabById: (id: string) => void } }).setting.open();
-            (plugin.app as unknown as { setting: { open: () => void; openTabById: (id: string) => void } }).setting.openTabById('s3-sync-and-backup');
+            (plugin.app as unknown as { setting: { open: () => void; openTabById: (id: string) => void } }).setting.openTabById('simple-storage-sync-and-backup');
         },
     });
 
@@ -144,7 +144,7 @@ export function registerCommands(plugin: S3SyncBackupPlugin): void {
         name: 'Open settings',
         callback: () => {
             (plugin.app as unknown as { setting: { open: () => void; openTabById: (id: string) => void } }).setting.open();
-            (plugin.app as unknown as { setting: { open: () => void; openTabById: (id: string) => void } }).setting.openTabById('s3-sync-and-backup');
+            (plugin.app as unknown as { setting: { open: () => void; openTabById: (id: string) => void } }).setting.openTabById('simple-storage-sync-and-backup');
         },
     });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -548,7 +548,7 @@ export default class S3SyncBackupPlugin extends Plugin {
 			name: 'Open settings',
 			callback: () => {
 				(this.app as unknown as { setting: { open: () => void; openTabById: (id: string) => void } }).setting.open();
-				(this.app as unknown as { setting: { open: () => void; openTabById: (id: string) => void } }).setting.openTabById('s3-sync-and-backup');
+				(this.app as unknown as { setting: { open: () => void; openTabById: (id: string) => void } }).setting.openTabById('simple-storage-sync-and-backup');
 			},
 		});
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -312,7 +312,7 @@ export function isConflictFile(path: string): boolean {
  * The plugin's manifest ID, used to construct the hardcoded exclusion path.
  * Must match the `id` field in `manifest.json`.
  */
-const PLUGIN_ID = 's3-sync-and-backup';
+const PLUGIN_ID = 'simple-storage-sync-and-backup';
 
 /**
  * Check whether a vault-relative path falls inside this plugin's own settings directory.

--- a/tests/e2e/backup-workflow.e2e.test.ts
+++ b/tests/e2e/backup-workflow.e2e.test.ts
@@ -313,7 +313,7 @@ describeIfS3('Backup workflow E2E', () => {
 
 		it('excludes the plugin settings directory from backups even when the file exists in the vault', async () => {
 			const device = await createInitializedDevice();
-			device.vault.seed('.obsidian/plugins/s3-sync-and-backup/data.json', '{"token":"secret"}');
+			device.vault.seed('.obsidian/plugins/simple-storage-sync-and-backup/data.json', '{"token":"secret"}');
 			device.vault.seed('notes/keep.md', 'safe content');
 
 			const result = await device.snapshotCreator.createSnapshot(device.deviceId, 'E2EDevice');
@@ -324,9 +324,9 @@ describeIfS3('Backup workflow E2E', () => {
 			expect(result.filesBackedUp).toBe(1);
 			expect(backupObjects).toContain(getBackupObjectKey(device, result.backupName, 'notes/keep.md'));
 			expect(backupObjects).not.toContain(
-				getBackupObjectKey(device, result.backupName, '.obsidian/plugins/s3-sync-and-backup/data.json'),
+				getBackupObjectKey(device, result.backupName, '.obsidian/plugins/simple-storage-sync-and-backup/data.json'),
 			);
-			expect(manifest.checksums).not.toHaveProperty('.obsidian/plugins/s3-sync-and-backup/data.json');
+			expect(manifest.checksums).not.toHaveProperty('.obsidian/plugins/simple-storage-sync-and-backup/data.json');
 		});
 	});
 

--- a/tests/utils/paths.test.ts
+++ b/tests/utils/paths.test.ts
@@ -244,15 +244,15 @@ describe('Path Utils', () => {
 
     describe('isPluginOwnPath', () => {
         it('should match data.json inside plugin directory', () => {
-            expect(isPluginOwnPath('.obsidian/plugins/s3-sync-and-backup/data.json', '.obsidian')).toBe(true);
+            expect(isPluginOwnPath('.obsidian/plugins/simple-storage-sync-and-backup/data.json', '.obsidian')).toBe(true);
         });
 
         it('should match main.js inside plugin directory', () => {
-            expect(isPluginOwnPath('.obsidian/plugins/s3-sync-and-backup/main.js', '.obsidian')).toBe(true);
+            expect(isPluginOwnPath('.obsidian/plugins/simple-storage-sync-and-backup/main.js', '.obsidian')).toBe(true);
         });
 
         it('should match the plugin directory itself', () => {
-            expect(isPluginOwnPath('.obsidian/plugins/s3-sync-and-backup', '.obsidian')).toBe(true);
+            expect(isPluginOwnPath('.obsidian/plugins/simple-storage-sync-and-backup', '.obsidian')).toBe(true);
         });
 
         it('should not match other plugin directories', () => {
@@ -265,12 +265,12 @@ describe('Path Utils', () => {
         });
 
         it('should work with custom configDir', () => {
-            expect(isPluginOwnPath('.config/plugins/s3-sync-and-backup/data.json', '.config')).toBe(true);
-            expect(isPluginOwnPath('.obsidian/plugins/s3-sync-and-backup/data.json', '.config')).toBe(false);
+            expect(isPluginOwnPath('.config/plugins/simple-storage-sync-and-backup/data.json', '.config')).toBe(true);
+            expect(isPluginOwnPath('.obsidian/plugins/simple-storage-sync-and-backup/data.json', '.config')).toBe(false);
         });
 
         it('should normalize backslashes in path', () => {
-            expect(isPluginOwnPath('.obsidian\\plugins\\s3-sync-and-backup\\data.json', '.obsidian')).toBe(true);
+            expect(isPluginOwnPath('.obsidian\\plugins\\simple-storage-sync-and-backup\\data.json', '.obsidian')).toBe(true);
         });
     });
 });


### PR DESCRIPTION
## Summary

- Renames plugin id from `s3-sync-and-backup` to `simple-storage-sync-and-backup` — the new community.obsidian.md submission portal enforces `/^[a-z-]+$/` (lowercase letters and hyphens only), rejecting the digit `3` in the previous id.
- Updates all in-tree references: `PLUGIN_ID` constant in `src/utils/paths.ts` (drives `isPluginOwnPath`), `openTabById` calls in `src/commands.ts` and `src/main.ts`, install-folder docs in README/CONTRIBUTING/AGENTS, and the `isPluginOwnPath` / backup-exclusion test fixtures.
- GitHub repo name (`obsidian-s3-sync-and-backup`), `package.json` `name`, release-please `package-name`, and Codecov badge slug all remain unchanged — they identify the repo, not the plugin.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:unit` — 548/548 passing
- [ ] After merge, build and re-upload `main.js` / `manifest.json` / `styles.css` to a new GitHub release before re-submitting to community.obsidian.md
- [ ] Manual install sanity check: copy build into `<Vault>/.obsidian/plugins/simple-storage-sync-and-backup/`, enable, confirm settings tab opens via the `Open settings` and `View backups` commands (both call `openTabById('simple-storage-sync-and-backup')`)