### PR TITLE
fix: address Obsidian community-store automated-review findings

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -37,10 +37,16 @@ on:
         type: boolean
         default: true
 
-# Required permissions for release-please to create PRs and releases
+# Required permissions for release-please to create PRs and releases.
+# `id-token: write` and `attestations: write` are required by the
+# `actions/attest-build-provenance` step in the build-and-publish job below;
+# they let the workflow request a Sigstore OIDC token and write the resulting
+# build-provenance attestations to the repository's attestations index.
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
+  attestations: write
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -153,6 +159,22 @@ jobs:
             [ -f "$file" ] || { echo "[X] $file not found"; exit 1; }
           done
           echo "[OK] All release artifacts present"
+
+      # ---------------------------------------------------------------------------
+      # Generate Build Provenance Attestations
+      # ---------------------------------------------------------------------------
+      # Cryptographically signs the release artefacts so users (and the
+      # Obsidian community-plugin review) can verify they were built from
+      # this repository's source via this workflow. Attestations are written
+      # to the repo's attestations index and are visible on the Release page.
+      # See: https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations
+      # ---------------------------------------------------------------------------
+      - name: Generate Artifact Attestations
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: |
+            main.js
+            styles.css
 
       # ---------------------------------------------------------------------------
       # Upload Release Assets

--- a/README.md
+++ b/README.md
@@ -199,8 +199,12 @@ your-bucket/
 
 - **Encryption algorithm:** XSalsa20-Poly1305 (via tweetnacl) with Argon2id key derivation (via hash-wasm).
 - **Content identity:** SHA-256 fingerprints of plaintext content, stored in S3 custom metadata.
-- **No telemetry:** The plugin makes no network calls except to your configured S3 endpoint.
-- **No remote code execution:** All encryption and hashing runs locally in the browser.
+- **Network use:** Outbound network requests go **only** to the S3-compatible endpoint you configure (AWS S3, Cloudflare R2, or RustFS) over HTTPS. No third-party services, telemetry endpoints, analytics, or update servers are contacted. The plugin performs the following kinds of network activity, all under your control:
+    - **Periodic sync** polls your bucket on a user-configurable interval (default 5 minutes, range 1–30 minutes). Controlled by the *Enable sync* and *Auto-sync* toggles plus the *Sync interval* dropdown in Settings — turning either toggle off stops all scheduled sync traffic.
+    - **Periodic backups** snapshot your vault on a user-configurable schedule (default daily, options from hourly to weekly). Controlled by the *Enable backups* toggle and the *Backup interval* dropdown.
+    - **Manual operations** (sync now, backup now, test connection, download backup) only run when you invoke them from the command palette, status bar, or settings.
+- **No telemetry:** The plugin sends no usage data, error reports, or identifiers anywhere. Disabling sync and backups stops all network activity completely.
+- **No remote code execution:** All encryption and hashing runs locally in the browser. The plugin never fetches or evaluates code from the network.
 - **Credential protection:** S3 credentials and saved passphrases are stored in Obsidian's `data.json`, which is hardcoded-excluded from sync to prevent leakage.
 
 ---

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -8,6 +8,13 @@ export default tseslint.config(
 		languageOptions: {
 			globals: {
 				...globals.browser,
+				// Obsidian-provided globals for popout-window compatibility.
+				// `activeDocument` resolves to the focused document (main or
+				// popout) and `activeWindow` to the focused window. The lint
+				// rules in `eslint-plugin-obsidianmd` push code toward these
+				// over the bare `document` / `window`.
+				activeDocument: "readonly",
+				activeWindow: "readonly",
 			},
 			parserOptions: {
 				projectService: {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"id": "simple-storage-sync-and-backup",
 	"name": "S3 Sync & Backup",
 	"version": "4.0.3",
-	"minAppVersion": "1.0.0",
+	"minAppVersion": "1.8.7",
 	"description": "Vault synchronization and scheduled backups across devices using S3-compatible storage (AWS S3, Cloudflare R2, RustFS, etc.) with optional end-to-end encryption.",
 	"author": "Ceilão Labs",
 	"authorUrl": "https://github.com/ceilaolabs",

--- a/src/backup/BackupDownloader.ts
+++ b/src/backup/BackupDownloader.ts
@@ -241,12 +241,12 @@ export class BackupDownloader {
         // to a hidden <a> element, programmatically click it, then immediately clean up.
         // This is the only cross-browser way to trigger a file-save dialog from JS.
         const url = URL.createObjectURL(blob);
-        const link = document.createElement('a');
+        const link = activeDocument.createElement('a');
         link.href = url;
         link.download = `${backupName}.zip`;
-        document.body.appendChild(link);
+        activeDocument.body.appendChild(link);
         link.click();
-        document.body.removeChild(link);
+        activeDocument.body.removeChild(link);
         URL.revokeObjectURL(url);
     }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -283,7 +283,7 @@ export class S3SyncBackupSettingTab extends PluginSettingTab {
 			buttonEl.textContent = '✓ connected';
 
 			// Reset button text after delay
-			setTimeout(() => {
+			window.setTimeout(() => {
 				buttonEl.textContent = originalText;
 				buttonEl.disabled = false;
 			}, 2000);
@@ -294,7 +294,7 @@ export class S3SyncBackupSettingTab extends PluginSettingTab {
 			buttonEl.disabled = false;
 
 			// Reset button text after delay
-			setTimeout(() => {
+			window.setTimeout(() => {
 				buttonEl.textContent = originalText;
 			}, 2000);
 		}

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -87,7 +87,7 @@ export async function withRetry<T>(
  * Sleep for specified milliseconds
  */
 export function sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+    return new Promise((resolve) => window.setTimeout(resolve, ms));
 }
 
 /**

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -17,3 +17,23 @@ Object.defineProperty(global, 'crypto', {
         getRandomValues: (arr: Uint8Array) => crypto.randomFillSync(arr),
     },
 });
+
+// Polyfill `window` so `window.setTimeout` etc. resolve in the Node test
+// environment. Obsidian's lint rules require `window.setTimeout` in source
+// code (popout-window compatibility); production code runs in the renderer
+// where `window` is real, but Jest's `node` environment has no `window`
+// unless a test sets one up itself. Aliasing it to `globalThis` is enough
+// for the timer/event-loop APIs the source code reaches for.
+if (typeof (global as { window?: unknown }).window === 'undefined') {
+    (global as { window: typeof globalThis }).window = globalThis;
+}
+
+// Polyfill `activeDocument`. Obsidian exposes this global to make code work
+// across the main window and popout windows; in the renderer it points at
+// whichever document currently has focus. In tests we proxy it to the
+// current `document` so existing per-test `document` mocks (see
+// BackupDownloader.test.ts) automatically satisfy `activeDocument` reads.
+Object.defineProperty(global, 'activeDocument', {
+    configurable: true,
+    get: () => (global as { document?: Document }).document,
+});


### PR DESCRIPTION
## Summary

Clears every finding from the new community-plugin store's automated review so the resubmitted plugin can pass.

- **`fix(manifest)`** — bump `minAppVersion` from `1.0.0` to `1.8.7`. The plugin uses `App.loadLocalStorage`/`saveLocalStorage` (1.8.7), `FileManager.trashFile` (1.6.6), `setTooltip` (1.4.4), `Vault.createFolder` (1.4.0), and `ButtonComponent.setDisabled` (1.2.3); bumping the declared floor is simpler than refactoring six call sites to older APIs.
- **`fix(ui)`** — replace `document` with `activeDocument` in `BackupDownloader` and bare `setTimeout` with `window.setTimeout` in `settings.ts` and `utils/retry.ts` for popout-window compatibility. Adds matching polyfills in `tests/setup.ts` and registers `activeDocument`/`activeWindow` as ESLint globals so existing tests and lint stay clean.
- **`docs(readme)`** — expand the Security section with an explicit "Network use" disclosure listing the periodic activities (sync, backups), their default + configurable intervals, and the exact settings toggles that disable them. Satisfies the suspicious-behaviour rule for `setInterval` + network calls.
- **`ci(release)`** — add `actions/attest-build-provenance@v4` to the release workflow with `id-token: write` + `attestations: write` permissions, so `main.js` and `styles.css` ship with verifiable build provenance.

## Manual step at release time

`versions.json` needs a new entry mapping the next plugin version → `1.8.7`. Release-please bumps `manifest.json.version` via `extra-files`, but doesn't run `scripts/version.mjs`, so the entry must be added by hand on the Release PR:

```bash
node scripts/version.mjs <next-version>   # e.g. 4.0.4
git add versions.json
git commit --amend --no-edit
```

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:unit` — 548/548 passing
- [x] `npm run build` — passes
- [ ] After merge: confirm the new Release has attestations attached (`gh attestation verify main.js --owner ceilaolabs`)
- [ ] Manual popout-window smoke test in a real Obsidian vault: install build into `.obsidian/plugins/simple-storage-sync-and-backup/`, open Obsidian into a popout window, exercise Settings → Test connection, Backups → Download, and a manual sync — confirm no console errors
- [ ] Re-submit at community.obsidian.md once the next release ships and confirm all four prior findings are cleared