### PR TITLE
fix: issue with eTag with unexpected W/ prefix

### DIFF
--- a/src/storage/S3Provider.ts
+++ b/src/storage/S3Provider.ts
@@ -222,7 +222,7 @@ export class S3Provider {
                             key: item.Key,
                             size: item.Size || 0,
                             lastModified: item.LastModified || new Date(),
-                            etag: item.ETag,
+                            etag: this.normalizeETag(item.ETag),
                         });
                     }
                 }
@@ -414,7 +414,7 @@ export class S3Provider {
      * Map a raw AWS SDK `HeadObject` or `GetObject` response into the
      * plugin-specific {@link S3HeadResult} shape.
      *
-     * ETag quotes are stripped here (S3 always wraps the value in `"…"`).
+     * ETag is normalized here (quotes and optional `W/` weak prefix are stripped).
      * Custom metadata keys (`obsidian-sync-version`, `obsidian-fingerprint`,
      * `obsidian-mtime`, `obsidian-device-id`) are extracted from the
      * `Metadata` map and parsed where numeric.
@@ -432,7 +432,7 @@ export class S3Provider {
         const metadata = response.Metadata ?? {};
 
         return {
-            etag: response.ETag?.replace(/"/g, '') || '',
+            etag: this.normalizeETag(response.ETag),
             size: response.ContentLength || 0,
             lastModified: response.LastModified?.getTime() || 0,
             syncVersion: this.parseMetadataNumber(metadata['obsidian-sync-version']),
@@ -478,7 +478,7 @@ export class S3Provider {
      * Avoids the TOCTOU race of separate HeadObject + GetObject calls.
      *
      * @param key - Full S3 key.
-     * @returns Object with text content and cleaned ETag (quotes stripped), or
+     * @returns Object with text content and cleaned ETag (quotes/weak-prefix stripped), or
      *   `null` if the key does not exist.
      * @throws {Error} On S3/network errors other than 404.
      */
@@ -498,7 +498,7 @@ export class S3Provider {
 
             return {
                 text: new TextDecoder().decode(bytes),
-                etag: response.ETag?.replace(/"/g, '') ?? null,
+                etag: this.normalizeETag(response.ETag) || null,
             };
         } catch (error) {
             const err = error as Error & { name?: string };
@@ -541,7 +541,7 @@ export class S3Provider {
      * @param content - File bytes or UTF-8 string to upload.
      * @param options - Optional content type string, or an options object with
      *   `contentType`, `ifMatch`, `ifNoneMatch`, and/or `metadata` fields.
-     * @returns The ETag of the newly created/updated object (quotes stripped).
+     * @returns The ETag of the newly created/updated object (quotes/weak-prefix stripped).
      * @throws {Error} On S3/network error, or if a conditional header is not
      *   satisfied (HTTP 412 Precondition Failed).
      */
@@ -571,8 +571,8 @@ export class S3Provider {
             Metadata: metadata,
         }));
 
-		// Return cleaned ETag (remove quotes)
-		return response.ETag?.replace(/"/g, '') || '';
+		// Return cleaned ETag (remove quotes and weak prefix)
+		return this.normalizeETag(response.ETag);
 	}
 
 	/**
@@ -581,8 +581,8 @@ export class S3Provider {
 	 *
 	 * The S3 API mandates that entity-tag values in these headers are enclosed
 	 * in double-quotes or use the `W/"..."` weak-tag form.  Because this class
-	 * strips quotes from all returned ETags, they must be re-quoted here before
-	 * being forwarded to the AWS SDK.
+	 * strips quotes and weak prefixes from all returned ETags, they must be
+	 * re-quoted here before being forwarded to the AWS SDK.
 	 *
 	 * Passthrough cases (no wrapping applied):
 	 * - `undefined` / empty — returns `undefined` so the header is omitted.
@@ -603,6 +603,23 @@ export class S3Provider {
 
 		return `"${etag}"`;
 	}
+
+    /**
+     * Normalize an S3 ETag by stripping surrounding double-quotes and the
+     * optional `W/` weak-tag prefix.
+     *
+     * Callers always work with bare hex strings for consistency across
+     * providers (some like Cloudflare R2 return weak ETags more often than AWS).
+     *
+     * @param etag - Raw ETag from S3 response.
+     * @returns Normalized bare hex string, or empty string if input is falsy.
+     */
+    private normalizeETag(etag?: string): string {
+        if (!etag) {
+            return '';
+        }
+        return etag.replace(/^W\//, '').replace(/"/g, '');
+    }
 
     /**
      * Delete a single object from S3.
@@ -694,8 +711,8 @@ export class S3Provider {
      * Fetch only the ETag of an S3 object, suitable for pre-flight checks
      * before conditional writes or deletes.
      *
-     * The returned ETag has its surrounding double-quotes stripped (e.g.
-     * `"abc123"` → `"abc123"`).
+     * The returned ETag has its surrounding double-quotes and optional `W/`
+     * weak-tag prefix stripped (e.g. `W/"abc123"` → `"abc123"`).
      *
      * @param key - Full S3 key.
      * @returns Bare ETag hex string, or `null` if the key does not exist.
@@ -708,8 +725,8 @@ export class S3Provider {
                 Bucket: this.settings.bucket,
                 Key: key,
             }));
-            // Return cleaned ETag (remove quotes)
-            return response.ETag?.replace(/"/g, '') || null;
+            // Return cleaned ETag (remove quotes and weak prefix)
+            return this.normalizeETag(response.ETag) || null;
         } catch (error) {
             const err = error as Error & { name?: string };
             if (err.name === 'NoSuchKey' || err.name === 'NotFound') {
@@ -728,7 +745,7 @@ export class S3Provider {
      * and size checks.
      *
      * @param key - Full S3 key.
-     * @returns Object info with ETag (quotes stripped), or `null` if not found.
+     * @returns Object info with ETag (quotes and weak prefix stripped), or `null` if not found.
      * @throws {Error} On S3/network errors other than 404.
      */
     async getFileMetadata(key: string): Promise<S3ObjectInfo | null> {
@@ -742,7 +759,7 @@ export class S3Provider {
                 key,
                 size: response.ContentLength || 0,
                 lastModified: response.LastModified || new Date(),
-                etag: response.ETag?.replace(/"/g, ''),
+                etag: this.normalizeETag(response.ETag),
             };
         } catch (error) {
             const err = error as Error & { name?: string };

--- a/src/sync/SyncPlanner.ts
+++ b/src/sync/SyncPlanner.ts
@@ -166,7 +166,7 @@ export class SyncPlanner {
 
 			if (item.action !== 'skip') {
 				if (ctx.remote?.objectInfo.etag) {
-					item.expectedRemoteEtag = ctx.remote.objectInfo.etag.replace(/"/g, '');
+					item.expectedRemoteEtag = ctx.remote.objectInfo.etag;
 				}
 				if (!ctx.remote) {
 					item.expectRemoteAbsent = true;
@@ -225,7 +225,7 @@ export class SyncPlanner {
 
 			const ctx = this.getOrCreate(contexts, localPath);
 			ctx.remote = {
-				objectInfo: { ...obj, etag: obj.etag?.replace(/"/g, '') },
+				objectInfo: obj,
 			};
 		}
 

--- a/tests/storage/S3Provider.test.ts
+++ b/tests/storage/S3Provider.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for S3Provider request shaping.
  */
 
-import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { ListObjectsV2Command, PutObjectCommand } from '@aws-sdk/client-s3';
 import { S3Provider } from '../../src/storage/S3Provider';
 import { S3SyncBackupSettings } from '../../src/types';
 
@@ -115,6 +115,88 @@ describe('S3Provider', () => {
 			const result = await provider.downloadFileAsTextWithEtag('vault/test.md');
 
 			expect(result).toEqual({ text: 'plain text', etag: 'etag-str' });
+		});
+	});
+
+	/**
+	 * Regression coverage for the ETag normalization contract. S3-compatible
+	 * storage (notably Cloudflare R2) can return weak entity-tags of the form
+	 * `W/"abc"`. Every S3Provider method that surfaces an ETag to callers must
+	 * strip both the `W/` weak-tag prefix and surrounding double-quotes so the
+	 * sync engine can compare ETags against its own bare-form baselines.
+	 */
+	describe('ETag normalization', () => {
+		it('strips W/ weak prefix from getFileEtag response', async () => {
+			const provider = new S3Provider(createSettings());
+			const send = jest.fn().mockResolvedValue({ ETag: 'W/"weak-etag"' });
+			(provider as unknown as { client: { send: typeof send } }).client = { send };
+
+			const etag = await provider.getFileEtag('vault/test.md');
+
+			expect(etag).toBe('weak-etag');
+		});
+
+		it('strips W/ weak prefix from downloadFileAsTextWithEtag response', async () => {
+			const provider = new S3Provider(createSettings());
+			const send = jest.fn().mockResolvedValue({
+				Body: new TextEncoder().encode('payload'),
+				ETag: 'W/"weak-etag"',
+			});
+			(provider as unknown as { client: { send: typeof send } }).client = { send };
+
+			const result = await provider.downloadFileAsTextWithEtag('vault/test.md');
+
+			expect(result).toEqual({ text: 'payload', etag: 'weak-etag' });
+		});
+
+		it('strips W/ weak prefix from listObjects entries', async () => {
+			const provider = new S3Provider(createSettings());
+			const send = jest.fn().mockResolvedValue({
+				Contents: [
+					{ Key: 'vault/a.md', Size: 1, LastModified: new Date(0), ETag: 'W/"weak-a"' },
+					{ Key: 'vault/b.md', Size: 2, LastModified: new Date(0), ETag: '"strong-b"' },
+				],
+			});
+			(provider as unknown as { client: { send: typeof send } }).client = { send };
+
+			const objects = await provider.listObjects('vault/');
+
+			expect(send.mock.calls[0][0]).toBeInstanceOf(ListObjectsV2Command);
+			expect(objects.map((o) => o.etag)).toEqual(['weak-a', 'strong-b']);
+		});
+
+		it('strips W/ weak prefix from uploadFile response', async () => {
+			const provider = new S3Provider(createSettings());
+			const send = jest.fn().mockResolvedValue({ ETag: 'W/"weak-uploaded"' });
+			(provider as unknown as { client: { send: typeof send } }).client = { send };
+
+			const etag = await provider.uploadFile('vault/test.md', 'hello');
+
+			expect(etag).toBe('weak-uploaded');
+		});
+
+		it('strips W/ weak prefix from getFileMetadata response', async () => {
+			const provider = new S3Provider(createSettings());
+			const send = jest.fn().mockResolvedValue({
+				ETag: 'W/"weak-meta"',
+				ContentLength: 42,
+				LastModified: new Date(0),
+			});
+			(provider as unknown as { client: { send: typeof send } }).client = { send };
+
+			const info = await provider.getFileMetadata('vault/test.md');
+
+			expect(info?.etag).toBe('weak-meta');
+		});
+
+		it('returns null from getFileEtag when the response ETag is missing', async () => {
+			const provider = new S3Provider(createSettings());
+			const send = jest.fn().mockResolvedValue({ ETag: undefined });
+			(provider as unknown as { client: { send: typeof send } }).client = { send };
+
+			const etag = await provider.getFileEtag('vault/test.md');
+
+			expect(etag).toBeNull();
 		});
 	});
 });

--- a/tests/sync/SyncPlanner.test.ts
+++ b/tests/sync/SyncPlanner.test.ts
@@ -321,7 +321,7 @@ describe('SyncPlanner', () => {
 		it('filters skip items when local and remote both match the baseline', async () => {
 			addVaultFile('stable.md', '1234567890', 500, 10);
 			s3Provider.listObjects.mockResolvedValue([
-				createRemoteObject({ key: 'vault/stable.md', size: 10, etag: '"etag-stable"' }),
+				createRemoteObject({ key: 'vault/stable.md', size: 10, etag: 'etag-stable' }),
 			]);
 			journal.getAllStateRecords.mockResolvedValue([
 				createStateRecord({
@@ -371,17 +371,19 @@ describe('SyncPlanner', () => {
 			]);
 		});
 
-		it('strips quotes from remote ETags before attaching them to plan items', async () => {
+		it('propagates the remote ETag to plan items as expectedRemoteEtag', async () => {
+			// S3Provider normalizes ETags (strips W/ weak prefix and double-quotes)
+			// before they reach SyncPlanner, so the planner forwards them as-is.
 			s3Provider.listObjects.mockResolvedValue([
-				createRemoteObject({ key: 'vault/quoted.md', etag: '"abc"' }),
+				createRemoteObject({ key: 'vault/normalized.md', etag: 'abc' }),
 			]);
-			mockedDecide.mockReturnValue(createPlanItem('quoted.md', 'download'));
+			mockedDecide.mockReturnValue(createPlanItem('normalized.md', 'download'));
 
 			const plan = await planner.buildPlan();
 
 			expect(plan).toEqual([
 				expect.objectContaining({
-					path: 'quoted.md',
+					path: 'normalized.md',
 					expectedRemoteEtag: 'abc',
 				}),
 			]);
@@ -457,7 +459,7 @@ describe('SyncPlanner', () => {
 			addVaultFile('dir/LOCAL_note.md');
 			addVaultFile('dir/REMOTE_note.md');
 			s3Provider.listObjects.mockResolvedValue([
-				createRemoteObject({ key: 'vault/dir/note.md', etag: '"remote-etag"' }),
+				createRemoteObject({ key: 'vault/dir/note.md', etag: 'remote-etag' }),
 				createRemoteObject({ key: 'vault/.obsidian-s3-sync/engine.json' }),
 			]);
 			pathCodec.isMetadataKey.mockImplementation((key) => key.includes('.obsidian-s3-sync/engine.json'));


### PR DESCRIPTION
I was facing an issue with the plugin not being able to delete remote files where it would error out something like this:

```
[S3 Sync] delete-remote failed for test.md: Remote file test.md changed since planning (expected ETag some_e_tag, got W/some_e_tag). Skipping delete.
```

And then it would mess with the entire syncing process.

I've written a helper function which cleans up the ETag and my build of the plugin works perfectly now.