### PR TITLE
fix(sync): prevent stale-journal mass-delete on destination change (CLO-3)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -162,6 +162,15 @@ export default class S3SyncBackupPlugin extends Plugin {
 					conflictCount: result.conflicts.length,
 					lastError: result.errors[0]?.message ?? null,
 				});
+
+				// Non-recoverable safety refusals (e.g. destructive plan blocked) must
+				// surface as a Notice regardless of trigger source.  Without this,
+				// scheduled/startup syncs would bury the actionable message in the
+				// status-bar tooltip.
+				const nonRecoverable = result.errors.find((error) => !error.recoverable);
+				if (nonRecoverable) {
+					new Notice(`Sync blocked: ${nonRecoverable.message}`, 15000);
+				}
 			},
 			onSyncError: (error) => {
 				this.statusBar?.updateSyncState({
@@ -596,6 +605,11 @@ export default class S3SyncBackupPlugin extends Plugin {
 		const result = await this.syncScheduler?.triggerSync('manual');
 
 		if (!result) {
+			// triggerSync returns null on unhandled engine throws or when a sync was
+			// silently skipped (e.g. encryption coordinator just blocked).  Either way
+			// the user clicked "sync now" and deserves a follow-up message rather than
+			// a status bar left on "syncing".
+			new Notice('Sync did not run — check logs or status bar for details.');
 			return;
 		}
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -572,6 +572,22 @@ export class S3SyncBackupSettingTab extends PluginSettingTab {
 		});
 	}
 
+	/**
+	 * Show the confirmation modal for resetting the sync journal.
+	 *
+	 * The journal stores per-file baselines used by three-way reconciliation.
+	 * Clearing it is non-destructive on its own — the very next sync simply
+	 * re-uploads every file from the vault as if for the first time.
+	 *
+	 * @returns A Promise that resolves with `true` when the user confirms.
+	 */
+	private showJournalResetConfirmation(): Promise<boolean> {
+		return new Promise((resolve) => {
+			const modal = new ResetSyncJournalModal(this.app, resolve);
+			modal.open();
+		});
+	}
+
 	private openBackupListModal(): void {
 		const retentionManager = this.plugin.getRetentionManager();
 		const backupDownloader = this.plugin.getBackupDownloader();
@@ -851,6 +867,31 @@ export class S3SyncBackupSettingTab extends PluginSettingTab {
 				});
 			});
 
+		// Reset sync journal
+		new Setting(containerEl)
+			.setName('Reset sync journal')
+			.setDesc(
+				'Discard per-file sync baselines for this vault.  Use when sync has been blocked ' +
+				'because the configured destination is unfamiliar, or to force a fresh full upload.',
+			)
+			.addButton((button) => {
+				button.setButtonText('Reset journal');
+				button.setWarning();
+				button.onClick(async () => {
+					const confirmed = await this.showJournalResetConfirmation();
+					if (!confirmed) return;
+
+					const journal = this.plugin.getSyncJournal();
+					if (!journal) {
+						new Notice('Sync system not initialised yet — try again in a moment.');
+						return;
+					}
+
+					await journal.clear();
+					new Notice('Sync journal reset — the next sync will re-upload every file.');
+				});
+			});
+
 		// Reset to defaults
 		new Setting(containerEl)
 			.setName('Reset to defaults')
@@ -924,6 +965,59 @@ class DisableEncryptionModal extends Modal {
 
 		const confirmBtn = buttonContainer.createEl('button', {
 			text: 'Disable encryption',
+			cls: 'mod-warning',
+		});
+		confirmBtn.addEventListener('click', () => {
+			this.resolve(true);
+			this.close();
+		});
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+		this.resolve(false);
+	}
+}
+
+/**
+ * Confirmation modal shown when the user requests to reset the sync journal.
+ *
+ * Clearing the journal removes every per-file baseline (mtime, size, fingerprint,
+ * etag) so the next sync treats every vault file as new and re-uploads it.  No
+ * S3 objects or local files are deleted by this action.  Resolves the Promise
+ * with `true` on confirm, `false` on cancel or close.
+ */
+class ResetSyncJournalModal extends Modal {
+	private resolve: (value: boolean) => void;
+
+	constructor(app: App, resolve: (value: boolean) => void) {
+		super(app);
+		this.resolve = resolve;
+	}
+
+	onOpen(): void {
+		const { contentEl } = this;
+
+		contentEl.createEl('h2', { text: 'Reset sync journal?' });
+
+		contentEl.createEl('p', {
+			text:
+				'This clears per-file sync baselines stored locally for this vault.  ' +
+				'The next sync will treat every file as new and re-upload it to S3.  ' +
+				'No vault files or S3 objects are deleted by this action.',
+		});
+
+		const buttonContainer = contentEl.createDiv({ cls: 'modal-button-container' });
+
+		buttonContainer
+			.createEl('button', { text: 'Cancel' })
+			.addEventListener('click', () => {
+				this.resolve(false);
+				this.close();
+			});
+
+		const confirmBtn = buttonContainer.createEl('button', {
+			text: 'Reset journal',
 			cls: 'mod-warning',
 		});
 		confirmBtn.addEventListener('click', () => {

--- a/src/sync/DestinationFingerprint.ts
+++ b/src/sync/DestinationFingerprint.ts
@@ -20,20 +20,33 @@ import { normalizePrefix } from '../utils/paths';
  * Compute a stable, comparable string representation of the destination a sync
  * journal was built against.
  *
- * Two settings objects produce the same fingerprint exactly when they describe
- * the same physical S3 location. The fingerprint is meant for equality
- * comparison only; it is not cryptographically secure and should not be parsed.
+ * The fingerprint is the canonical JSON serialisation of a fixed-shape object
+ * containing only the destination-affecting settings.  JSON quoting escapes
+ * delimiter characters, so user-controlled fields (e.g. `syncPrefix`) cannot
+ * craft a value that collides with a different destination.
+ *
+ * Two settings objects produce the same fingerprint when their destination
+ * fields match after `normalizePrefix` is applied to `syncPrefix`.  Other
+ * forms of equivalence (e.g. case-normalised endpoint hostnames, trailing
+ * slashes in `endpoint`, alternate URL schemes) are intentionally not
+ * resolved — distinct spellings of the same physical location compare
+ * non-equal and are treated as a destination change.
+ *
+ * The fingerprint is meant for equality comparison only; it is not
+ * cryptographically secure and should not be parsed.
  *
  * @param settings - Plugin settings whose destination fields will be hashed.
  * @returns A deterministic string suitable for storage in the journal metadata.
  */
 export function computeDestinationFingerprint(settings: S3SyncBackupSettings): string {
-	const parts = [
-		`provider=${settings.provider}`,
-		`region=${settings.region}`,
-		`endpoint=${settings.endpoint}`,
-		`bucket=${settings.bucket}`,
-		`prefix=${normalizePrefix(settings.syncPrefix)}`,
-	];
-	return parts.join('|');
+	// Keys are fixed in declaration order; JSON.stringify preserves it so the
+	// output is deterministic without an explicit sort.
+	const payload = {
+		provider: settings.provider,
+		region: settings.region,
+		endpoint: settings.endpoint,
+		bucket: settings.bucket,
+		prefix: normalizePrefix(settings.syncPrefix),
+	};
+	return JSON.stringify(payload);
 }

--- a/src/sync/DestinationFingerprint.ts
+++ b/src/sync/DestinationFingerprint.ts
@@ -1,0 +1,39 @@
+/**
+ * Deterministic fingerprint of the S3 destination a sync journal was built against.
+ *
+ * The journal (IndexedDB at `obsidian-s3-sync-journal-{vaultName}`) is keyed by
+ * vault name only, so the same vault pointed at different remotes shares the same
+ * journal. Without a way to detect that the remote has changed, baselines from a
+ * previous destination would drive a destructive sync plan against a new
+ * (effectively empty) one — see the regression that motivated this module.
+ *
+ * The fingerprint covers every settings field that affects *where the data lives*:
+ * provider, region, endpoint, bucket, and the normalised sync prefix. Credential
+ * fields (access keys, passphrase storage) are intentionally excluded — rotating
+ * keys does not move the data, so the journal remains valid.
+ */
+
+import { S3SyncBackupSettings } from '../types';
+import { normalizePrefix } from '../utils/paths';
+
+/**
+ * Compute a stable, comparable string representation of the destination a sync
+ * journal was built against.
+ *
+ * Two settings objects produce the same fingerprint exactly when they describe
+ * the same physical S3 location. The fingerprint is meant for equality
+ * comparison only; it is not cryptographically secure and should not be parsed.
+ *
+ * @param settings - Plugin settings whose destination fields will be hashed.
+ * @returns A deterministic string suitable for storage in the journal metadata.
+ */
+export function computeDestinationFingerprint(settings: S3SyncBackupSettings): string {
+	const parts = [
+		`provider=${settings.provider}`,
+		`region=${settings.region}`,
+		`endpoint=${settings.endpoint}`,
+		`bucket=${settings.bucket}`,
+		`prefix=${normalizePrefix(settings.syncPrefix)}`,
+	];
+	return parts.join('|');
+}

--- a/src/sync/SyncEngine.ts
+++ b/src/sync/SyncEngine.ts
@@ -14,7 +14,7 @@
  */
 
 import { App } from 'obsidian';
-import { S3SyncBackupSettings, SyncResult } from '../types';
+import { S3SyncBackupSettings, SyncPlanItem, SyncResult } from '../types';
 import { S3Provider } from '../storage/S3Provider';
 import { SyncJournal } from './SyncJournal';
 import { SyncPathCodec } from './SyncPathCodec';
@@ -34,6 +34,24 @@ import { computeDestinationFingerprint } from './DestinationFingerprint';
  * destructive plan.
  */
 const DESTINATION_FINGERPRINT_KEY = 'destinationFingerprint';
+
+/**
+ * Absolute upper bound on `delete-local` actions that may execute against a
+ * destination with no prior successful sync.  Tuned to be safely above any
+ * legitimate first-sync scenario (which produces no deletions at all) while
+ * still catching mass-delete bugs on small-to-medium vaults.
+ */
+const DESTRUCTIVE_DELETE_ABSOLUTE_THRESHOLD = 10;
+
+/**
+ * Ratio threshold for `delete-local` actions relative to the full plan size.
+ * Catches small vaults where the absolute count alone would not trigger
+ * (e.g. 5 deletions in a 5-item plan = 100 %).
+ */
+const DESTRUCTIVE_DELETE_RATIO_THRESHOLD = 0.5;
+
+/** Journal metadata key holding the epoch-ms time of the last successful sync. */
+const LAST_SUCCESSFUL_SYNC_KEY = 'lastSuccessfulSyncAt';
 
 /**
  * SyncEngine — orchestrates a complete sync cycle.
@@ -126,6 +144,15 @@ export class SyncEngine {
 			const plan = await planner.buildPlan();
 			this.log(`Plan contains ${plan.length} action(s)`);
 
+			// Phase 1.5 — Safety guard.  Refuse any plan that wants to mass-delete local
+			// files when this destination has never completed a successful sync.  This is a
+			// belt-and-braces backstop against future bugs that would otherwise drive a
+			// destructive plan past the destination-fingerprint check.
+			const guardError = await this.checkDestructivePlan(plan);
+			if (guardError) {
+				return this.buildBlockedResult(guardError);
+			}
+
 			// Phase 2 — Execute
 			const executor = new SyncExecutor(
 				this.app,
@@ -141,7 +168,7 @@ export class SyncEngine {
 
 			// Phase 3 — Persist metadata
 			if (result.success) {
-				await this.journal.setMetadata('lastSuccessfulSyncAt', Date.now());
+				await this.journal.setMetadata(LAST_SUCCESSFUL_SYNC_KEY, Date.now());
 			}
 
 			this.log(`Sync completed with ${result.errors.length} error(s)`);
@@ -194,6 +221,64 @@ export class SyncEngine {
 		}
 
 		await this.journal.setMetadata(DESTINATION_FINGERPRINT_KEY, current);
+	}
+
+	/**
+	 * Inspect a freshly built plan and return an error message when it would mass-delete
+	 * local files against a destination that has no prior successful sync recorded.
+	 *
+	 * Triggers on either condition:
+	 * - Absolute count: more than {@link DESTRUCTIVE_DELETE_ABSOLUTE_THRESHOLD} `delete-local` actions.
+	 * - Ratio: `delete-local` actions make up at least {@link DESTRUCTIVE_DELETE_RATIO_THRESHOLD}
+	 *   of the plan (catches small vaults the absolute threshold would miss).
+	 *
+	 * @param plan - Planner output to inspect.
+	 * @returns A human-readable error message when the plan should be blocked, or `null` to proceed.
+	 */
+	private async checkDestructivePlan(plan: SyncPlanItem[]): Promise<string | null> {
+		const deleteCount = plan.reduce((count, item) => item.action === 'delete-local' ? count + 1 : count, 0);
+		if (deleteCount === 0) return null;
+
+		const exceedsAbsolute = deleteCount > DESTRUCTIVE_DELETE_ABSOLUTE_THRESHOLD;
+		const exceedsRatio = plan.length > 0 && (deleteCount / plan.length) >= DESTRUCTIVE_DELETE_RATIO_THRESHOLD;
+		if (!exceedsAbsolute && !exceedsRatio) return null;
+
+		const hasPriorSuccess = (await this.journal.getMetadata(LAST_SUCCESSFUL_SYNC_KEY)) !== undefined;
+		if (hasPriorSuccess) return null;
+
+		return (
+			`Aborted: destructive plan blocked — ${deleteCount} of ${plan.length} action(s) would trash local files ` +
+			'against a destination that has no prior successful sync. ' +
+			'Verify the configured bucket and sync prefix point to the expected location, ' +
+			'then clear the sync journal from settings if a fresh re-upload is intended.'
+		);
+	}
+
+	/**
+	 * Construct a `SyncResult` representing a plan that was refused by the safety guard.
+	 *
+	 * The error is marked non-recoverable because retrying the same sync would re-trigger
+	 * the same guard; the user must take an explicit action (fix settings or reset the
+	 * journal) before another attempt makes sense.
+	 *
+	 * @param message - Human-readable explanation of why the plan was blocked.
+	 * @returns A populated `SyncResult` with `success: false` and a single error.
+	 */
+	private buildBlockedResult(message: string): SyncResult {
+		const now = Date.now();
+		console.error(`[S3 Sync] ${message}`);
+		return {
+			success: false,
+			startedAt: now,
+			completedAt: now,
+			filesUploaded: 0,
+			filesDownloaded: 0,
+			filesDeleted: 0,
+			filesAdopted: 0,
+			filesForgotten: 0,
+			conflicts: [],
+			errors: [{ path: '', action: 'delete-local', message, recoverable: false }],
+		};
 	}
 
 	/**

--- a/src/sync/SyncEngine.ts
+++ b/src/sync/SyncEngine.ts
@@ -4,10 +4,18 @@
  * Thin orchestrator that coordinates the three-way reconciliation sync:
  *   1. Acquire mutex (prevent concurrent syncs)
  *   2. Signal ChangeTracker that sync is active
- *   3. Build a plan via {@link SyncPlanner}
- *   4. Execute the plan via {@link SyncExecutor}
- *   5. Record `lastSuccessfulSyncAt` in journal metadata
- *   6. Release mutex and signal ChangeTracker
+ *   3. Phase 0 — Reconcile destination fingerprint: detect when the configured
+ *      S3 destination differs from the journal's last-known destination and
+ *      clear stale baselines so they cannot drive a destructive plan
+ *   4. Phase 1 — Build a plan via {@link SyncPlanner}
+ *   5. Phase 1.4 — Re-check that the destination has not changed during planning;
+ *      refuse the plan if the user mutated settings while the planner was
+ *      awaiting S3
+ *   6. Phase 1.5 — Refuse plans that would `delete-local` files against a
+ *      destination with no prior successful sync (belt-and-braces safety net)
+ *   7. Phase 2 — Execute the plan via {@link SyncExecutor}
+ *   8. Phase 3 — Record `lastSuccessfulSyncAt` in journal metadata on success
+ *   9. Release mutex and signal ChangeTracker
  *
  * All heavy lifting (state discovery, classification, decision-making,
  * file I/O, S3 operations) lives in the planner and executor modules.
@@ -35,23 +43,30 @@ import { computeDestinationFingerprint } from './DestinationFingerprint';
  */
 const DESTINATION_FINGERPRINT_KEY = 'destinationFingerprint';
 
-/**
- * Absolute upper bound on `delete-local` actions that may execute against a
- * destination with no prior successful sync.  Tuned to be safely above any
- * legitimate first-sync scenario (which produces no deletions at all) while
- * still catching mass-delete bugs on small-to-medium vaults.
- */
-const DESTRUCTIVE_DELETE_ABSOLUTE_THRESHOLD = 10;
-
-/**
- * Ratio threshold for `delete-local` actions relative to the full plan size.
- * Catches small vaults where the absolute count alone would not trigger
- * (e.g. 5 deletions in a 5-item plan = 100 %).
- */
-const DESTRUCTIVE_DELETE_RATIO_THRESHOLD = 0.5;
-
 /** Journal metadata key holding the epoch-ms time of the last successful sync. */
 const LAST_SUCCESSFUL_SYNC_KEY = 'lastSuccessfulSyncAt';
+
+/**
+ * Run a journal operation and rewrap any thrown error with a phase description.
+ *
+ * The outer `sync()` catch logs only the final message, so without a phase
+ * description an IndexedDB failure surfaces as a bare "Sync failed: <message>"
+ * with no indication of which journal touchpoint failed.  Wrapping each step
+ * preserves the underlying error message while making the operation visible.
+ *
+ * @param phase     - Short human description of what was being attempted.
+ * @param operation - Thunk producing the journal call to await.
+ * @returns The operation's resolved value.
+ * @throws An `Error` whose message includes the phase and the underlying message.
+ */
+async function withJournalContext<T>(phase: string, operation: () => Promise<T>): Promise<T> {
+	try {
+		return await operation();
+	} catch (error) {
+		const cause = error instanceof Error ? error.message : String(error);
+		throw new Error(`Failed ${phase}: ${cause}`);
+	}
+}
 
 /**
  * SyncEngine — orchestrates a complete sync cycle.
@@ -129,8 +144,11 @@ export class SyncEngine {
 			// vault pointed at a new bucket/prefix would otherwise reuse baselines from the
 			// previous destination and trigger a destructive plan (untouched local files
 			// classified as "remotely deleted").  Detect the mismatch and clear stale
-			// baselines before the planner runs.
-			await this.reconcileDestinationFingerprint();
+			// baselines before the planner runs.  The fingerprint captured here is also
+			// the snapshot we re-validate against after planning to close the
+			// settings-mutated-mid-sync race.
+			const startFingerprint = computeDestinationFingerprint(this.settings);
+			await this.reconcileDestinationFingerprint(startFingerprint);
 
 			// Phase 1 — Plan
 			const planner = new SyncPlanner(
@@ -143,6 +161,17 @@ export class SyncEngine {
 			);
 			const plan = await planner.buildPlan();
 			this.log(`Plan contains ${plan.length} action(s)`);
+
+			// Phase 1.4 — Destination re-check.  The planner does async S3 I/O during
+			// which `updateSettings` could mutate this.settings / pathCodec / s3Provider
+			// to point at a different destination.  If that happened, the plan was built
+			// against a destination we never validated.  Refuse to execute it.
+			if (computeDestinationFingerprint(this.settings) !== startFingerprint) {
+				return this.buildBlockedResult(
+					'Aborted: destination changed during sync — settings were updated while the planner was running. ' +
+					'The pending sync was discarded; the next cycle will re-plan against the new destination.',
+				);
+			}
 
 			// Phase 1.5 — Safety guard.  Refuse any plan that wants to mass-delete local
 			// files when this destination has never completed a successful sync.  This is a
@@ -206,10 +235,15 @@ export class SyncEngine {
 	 *
 	 * The new fingerprint is also recorded on a true first sync (no stored value) so
 	 * subsequent destination changes are detectable.
+	 *
+	 * @param current - Fingerprint of the destination we are about to sync against,
+	 *   pre-computed by the caller so it can be reused as the snapshot for the
+	 *   post-plan recheck (avoids recomputing and avoids reading mutated settings).
 	 */
-	private async reconcileDestinationFingerprint(): Promise<void> {
-		const current = computeDestinationFingerprint(this.settings);
-		const stored = await this.journal.getMetadata(DESTINATION_FINGERPRINT_KEY);
+	private async reconcileDestinationFingerprint(current: string): Promise<void> {
+		const stored = await withJournalContext('reading stored destination fingerprint',
+			() => this.journal.getMetadata(DESTINATION_FINGERPRINT_KEY),
+		);
 
 		if (stored === current) {
 			return;
@@ -217,20 +251,26 @@ export class SyncEngine {
 
 		if (stored !== undefined) {
 			this.log('Destination changed — clearing stale journal baselines');
-			await this.journal.clear();
+			await withJournalContext('clearing stale journal baselines',
+				() => this.journal.clear(),
+			);
 		}
 
-		await this.journal.setMetadata(DESTINATION_FINGERPRINT_KEY, current);
+		await withJournalContext('recording new destination fingerprint',
+			() => this.journal.setMetadata(DESTINATION_FINGERPRINT_KEY, current),
+		);
 	}
 
 	/**
-	 * Inspect a freshly built plan and return an error message when it would mass-delete
+	 * Inspect a freshly built plan and return an error message when it would delete
 	 * local files against a destination that has no prior successful sync recorded.
 	 *
-	 * Triggers on either condition:
-	 * - Absolute count: more than {@link DESTRUCTIVE_DELETE_ABSOLUTE_THRESHOLD} `delete-local` actions.
-	 * - Ratio: `delete-local` actions make up at least {@link DESTRUCTIVE_DELETE_RATIO_THRESHOLD}
-	 *   of the plan (catches small vaults the absolute threshold would miss).
+	 * Rationale: a destination with no `lastSuccessfulSyncAt` either has an empty
+	 * journal (true first sync, or freshly cleared by Phase 0) or a journal that
+	 * could not be confirmed against any prior successful run.  In both cases the
+	 * decision table cannot legitimately emit `delete-local` — that action requires
+	 * a matching baseline, which a never-synced destination does not have.  Any
+	 * `delete-local` on such a destination is therefore a bug and is refused.
 	 *
 	 * @param plan - Planner output to inspect.
 	 * @returns A human-readable error message when the plan should be blocked, or `null` to proceed.
@@ -239,18 +279,16 @@ export class SyncEngine {
 		const deleteCount = plan.reduce((count, item) => item.action === 'delete-local' ? count + 1 : count, 0);
 		if (deleteCount === 0) return null;
 
-		const exceedsAbsolute = deleteCount > DESTRUCTIVE_DELETE_ABSOLUTE_THRESHOLD;
-		const exceedsRatio = plan.length > 0 && (deleteCount / plan.length) >= DESTRUCTIVE_DELETE_RATIO_THRESHOLD;
-		if (!exceedsAbsolute && !exceedsRatio) return null;
-
-		const hasPriorSuccess = (await this.journal.getMetadata(LAST_SUCCESSFUL_SYNC_KEY)) !== undefined;
+		const hasPriorSuccess = (await withJournalContext('reading prior successful sync timestamp',
+			() => this.journal.getMetadata(LAST_SUCCESSFUL_SYNC_KEY),
+		)) !== undefined;
 		if (hasPriorSuccess) return null;
 
 		return (
 			`Aborted: destructive plan blocked — ${deleteCount} of ${plan.length} action(s) would trash local files ` +
 			'against a destination that has no prior successful sync. ' +
 			'Verify the configured bucket and sync prefix point to the expected location, ' +
-			'then clear the sync journal from settings if a fresh re-upload is intended.'
+			'then use "Reset sync journal" in Advanced settings if a fresh re-upload is intended.'
 		);
 	}
 

--- a/src/sync/SyncEngine.ts
+++ b/src/sync/SyncEngine.ts
@@ -22,6 +22,18 @@ import { SyncPayloadCodec } from './SyncPayloadCodec';
 import { SyncPlanner } from './SyncPlanner';
 import { SyncExecutor } from './SyncExecutor';
 import { ChangeTracker } from './ChangeTracker';
+import { computeDestinationFingerprint } from './DestinationFingerprint';
+
+/**
+ * Journal metadata key under which the destination fingerprint is persisted.
+ *
+ * The fingerprint identifies the S3 destination (bucket / endpoint / region /
+ * prefix / provider) the journal's baselines were built against. A mismatch
+ * between the stored value and the current settings means the baselines refer
+ * to a different remote and must be discarded before they can drive a
+ * destructive plan.
+ */
+const DESTINATION_FINGERPRINT_KEY = 'destinationFingerprint';
 
 /**
  * SyncEngine — orchestrates a complete sync cycle.
@@ -95,6 +107,13 @@ export class SyncEngine {
 		try {
 			this.log('Starting sync');
 
+			// Phase 0 — Destination guard.  The journal is keyed by vault name only, so a
+			// vault pointed at a new bucket/prefix would otherwise reuse baselines from the
+			// previous destination and trigger a destructive plan (untouched local files
+			// classified as "remotely deleted").  Detect the mismatch and clear stale
+			// baselines before the planner runs.
+			await this.reconcileDestinationFingerprint();
+
 			// Phase 1 — Plan
 			const planner = new SyncPlanner(
 				this.app,
@@ -151,6 +170,30 @@ export class SyncEngine {
 			this.isSyncing = false;
 			this.changeTracker.setSyncInProgress(false);
 		}
+	}
+
+	/**
+	 * Compare the journal's stored destination fingerprint to the one derived from
+	 * current settings.  When they differ, wipe the journal so stale baselines from a
+	 * previous destination cannot drive a destructive plan, then record the new value.
+	 *
+	 * The new fingerprint is also recorded on a true first sync (no stored value) so
+	 * subsequent destination changes are detectable.
+	 */
+	private async reconcileDestinationFingerprint(): Promise<void> {
+		const current = computeDestinationFingerprint(this.settings);
+		const stored = await this.journal.getMetadata(DESTINATION_FINGERPRINT_KEY);
+
+		if (stored === current) {
+			return;
+		}
+
+		if (stored !== undefined) {
+			this.log('Destination changed — clearing stale journal baselines');
+			await this.journal.clear();
+		}
+
+		await this.journal.setMetadata(DESTINATION_FINGERPRINT_KEY, current);
 	}
 
 	/**

--- a/tests/sync/DestinationFingerprint.test.ts
+++ b/tests/sync/DestinationFingerprint.test.ts
@@ -40,6 +40,12 @@ function createSettings(overrides: Partial<S3SyncBackupSettings> = {}): S3SyncBa
 	};
 }
 
+/**
+ * Covers the pure-function destination fingerprint used by SyncEngine's Phase 0
+ * reconciliation: stability for identical settings, sensitivity to each
+ * destination-affecting field, prefix normalisation, delimiter-collision
+ * resistance, and credential-field exclusion.
+ */
 describe('computeDestinationFingerprint', () => {
 	it('returns the same string for two identical destinations', () => {
 		const a = computeDestinationFingerprint(createSettings());
@@ -88,6 +94,24 @@ describe('computeDestinationFingerprint', () => {
 	it('changes when the provider changes', () => {
 		const a = computeDestinationFingerprint(createSettings({ provider: 'aws' }));
 		const b = computeDestinationFingerprint(createSettings({ provider: 'r2' }));
+
+		expect(a).not.toBe(b);
+	});
+
+	it('does not collide when a field value contains the delimiter or key characters', () => {
+		// Naive `key=value|key=value` concatenation collides when a user-supplied
+		// field (e.g. syncPrefix) embeds `|` or `=`.  Two distinct destinations
+		// constructed below would otherwise produce identical fingerprints.
+		const a = computeDestinationFingerprint(createSettings({
+			endpoint: 'https://e|bucket=my-bucket|prefix=one',
+			bucket: 'my-bucket',
+			syncPrefix: 'two',
+		}));
+		const b = computeDestinationFingerprint(createSettings({
+			endpoint: 'https://e',
+			bucket: 'my-bucket',
+			syncPrefix: 'one|bucket=my-bucket|prefix=two',
+		}));
 
 		expect(a).not.toBe(b);
 	});

--- a/tests/sync/DestinationFingerprint.test.ts
+++ b/tests/sync/DestinationFingerprint.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for the destination fingerprint utility.
+ *
+ * The fingerprint is a deterministic identifier for the S3 destination a journal
+ * was built against. SyncEngine uses it to detect when the configured destination
+ * has changed (bucket / endpoint / region / sync prefix / provider) and to
+ * invalidate stale baselines that would otherwise drive a destructive sync plan.
+ */
+
+import { computeDestinationFingerprint } from '../../src/sync/DestinationFingerprint';
+import { S3SyncBackupSettings } from '../../src/types';
+
+function createSettings(overrides: Partial<S3SyncBackupSettings> = {}): S3SyncBackupSettings {
+	return {
+		provider: 'aws',
+		endpoint: '',
+		region: 'us-east-1',
+		bucket: 'my-bucket',
+		accessKeyId: 'ignored-key',
+		secretAccessKey: 'ignored-secret',
+		forcePathStyle: false,
+		encryptionEnabled: false,
+		rememberPassphrase: false,
+		savedPassphrase: '',
+		syncEnabled: true,
+		syncPrefix: 'vault',
+		autoSyncEnabled: false,
+		syncIntervalMinutes: 5,
+		syncOnStartup: false,
+		backupEnabled: false,
+		backupPrefix: 'backups',
+		backupInterval: '1day',
+		retentionEnabled: false,
+		retentionMode: 'copies',
+		retentionDays: 30,
+		retentionCopies: 30,
+		excludePatterns: [],
+		debugLogging: false,
+		...overrides,
+	};
+}
+
+describe('computeDestinationFingerprint', () => {
+	it('returns the same string for two identical destinations', () => {
+		const a = computeDestinationFingerprint(createSettings());
+		const b = computeDestinationFingerprint(createSettings());
+
+		expect(a).toBe(b);
+	});
+
+	it('changes when the bucket changes', () => {
+		const a = computeDestinationFingerprint(createSettings({ bucket: 'bucket-a' }));
+		const b = computeDestinationFingerprint(createSettings({ bucket: 'bucket-b' }));
+
+		expect(a).not.toBe(b);
+	});
+
+	it('changes when the sync prefix changes', () => {
+		const a = computeDestinationFingerprint(createSettings({ syncPrefix: 'vault' }));
+		const b = computeDestinationFingerprint(createSettings({ syncPrefix: 'archive' }));
+
+		expect(a).not.toBe(b);
+	});
+
+	it('treats equivalent prefix spellings as the same destination', () => {
+		// `normalizePrefix` strips surrounding slashes and collapses doubled slashes,
+		// so `"/vault/"` and `"vault"` point at the same S3 location.
+		const a = computeDestinationFingerprint(createSettings({ syncPrefix: 'vault' }));
+		const b = computeDestinationFingerprint(createSettings({ syncPrefix: '/vault/' }));
+
+		expect(a).toBe(b);
+	});
+
+	it('changes when the endpoint changes', () => {
+		const a = computeDestinationFingerprint(createSettings({ endpoint: 'https://s3.example.com' }));
+		const b = computeDestinationFingerprint(createSettings({ endpoint: 'https://s3.other.com' }));
+
+		expect(a).not.toBe(b);
+	});
+
+	it('changes when the region changes', () => {
+		const a = computeDestinationFingerprint(createSettings({ region: 'us-east-1' }));
+		const b = computeDestinationFingerprint(createSettings({ region: 'eu-west-1' }));
+
+		expect(a).not.toBe(b);
+	});
+
+	it('changes when the provider changes', () => {
+		const a = computeDestinationFingerprint(createSettings({ provider: 'aws' }));
+		const b = computeDestinationFingerprint(createSettings({ provider: 'r2' }));
+
+		expect(a).not.toBe(b);
+	});
+
+	it('ignores credential fields that do not affect data location', () => {
+		// Swapping IAM keys / passphrase settings does not move the data; the
+		// journal baselines remain valid and must not be invalidated.
+		const a = computeDestinationFingerprint(createSettings({
+			accessKeyId: 'key-a',
+			secretAccessKey: 'secret-a',
+			rememberPassphrase: false,
+			savedPassphrase: '',
+		}));
+		const b = computeDestinationFingerprint(createSettings({
+			accessKeyId: 'key-b',
+			secretAccessKey: 'secret-b',
+			rememberPassphrase: true,
+			savedPassphrase: 'changed',
+		}));
+
+		expect(a).toBe(b);
+	});
+});

--- a/tests/sync/SyncEngine.test.ts
+++ b/tests/sync/SyncEngine.test.ts
@@ -403,19 +403,38 @@ describe('SyncEngine', () => {
 
 			await context.engine.sync();
 
-			const expected = 'provider=aws|region=us-east-1|endpoint=|bucket=my-bucket|prefix=vault';
+			const expected = JSON.stringify({
+				provider: 'aws',
+				region: 'us-east-1',
+				endpoint: '',
+				bucket: 'my-bucket',
+				prefix: 'vault',
+			});
 			expect(context.journal.setMetadata).toHaveBeenCalledWith('destinationFingerprint', expected);
 			expect(context.journal.clear).not.toHaveBeenCalled();
 		});
 
 		it('clears stale baselines and records the new fingerprint when the destination changes', async () => {
 			const context = createEngineContext({ bucket: 'new-bucket', syncPrefix: 'vault' });
-			context.journal.getMetadata.mockResolvedValueOnce('provider=aws|region=us-east-1|endpoint=|bucket=old-bucket|prefix=vault');
+			const stale = JSON.stringify({
+				provider: 'aws',
+				region: 'us-east-1',
+				endpoint: '',
+				bucket: 'old-bucket',
+				prefix: 'vault',
+			});
+			context.journal.getMetadata.mockResolvedValueOnce(stale);
 
 			await context.engine.sync();
 
 			expect(context.journal.clear).toHaveBeenCalledTimes(1);
-			const expected = 'provider=aws|region=us-east-1|endpoint=|bucket=new-bucket|prefix=vault';
+			const expected = JSON.stringify({
+				provider: 'aws',
+				region: 'us-east-1',
+				endpoint: '',
+				bucket: 'new-bucket',
+				prefix: 'vault',
+			});
 			expect(context.journal.setMetadata).toHaveBeenCalledWith('destinationFingerprint', expected);
 			// Clear must happen before the planner runs so stale baselines cannot drive a destructive plan.
 			expect(context.journal.clear.mock.invocationCallOrder[0]).toBeLessThan(
@@ -423,9 +442,70 @@ describe('SyncEngine', () => {
 			);
 		});
 
+		it('aborts when the destination changes between the initial check and plan completion', async () => {
+			// The reconcile step runs before the planner, but the planner does async S3
+			// I/O during which the user could change destination-affecting settings.  A
+			// post-plan re-check must catch that and refuse to execute against a plan
+			// that was built against a different destination than the one we validated.
+			const context = createEngineContext({ bucket: 'bucket-a' });
+			const plannerDeferred = createDeferred<SyncPlanItem[]>();
+			context.planner.buildPlan.mockReturnValueOnce(plannerDeferred.promise);
+
+			const syncPromise = context.engine.sync();
+			// Simulate `saveSettings` flipping the destination while the planner is awaiting S3.
+			context.engine.updateSettings(createSettings({ bucket: 'bucket-b' }));
+			plannerDeferred.resolve([createPlanItem('notes/a.md', 'upload')]);
+
+			const result = await syncPromise;
+
+			expect(context.executor.execute).not.toHaveBeenCalled();
+			expect(result.success).toBe(false);
+			expect(result.errors[0]?.message).toMatch(/destination changed/i);
+		});
+
+		it('aborts before planning when clearing stale baselines fails', async () => {
+			// If clear() throws, the destructive plan guard can't run and the journal is
+			// in an uncertain state.  The engine must abort with a contextualised error
+			// rather than fall through to a planner that would see stale baselines.
+			const context = createEngineContext({ bucket: 'new-bucket' });
+			context.journal.getMetadata.mockResolvedValueOnce(JSON.stringify({
+				provider: 'aws', region: 'us-east-1', endpoint: '', bucket: 'old-bucket', prefix: 'vault',
+			}));
+			context.journal.clear.mockRejectedValueOnce(new Error('IDB write failure'));
+			const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+			const result = await context.engine.sync();
+
+			expect(context.planner.buildPlan).not.toHaveBeenCalled();
+			expect(context.executor.execute).not.toHaveBeenCalled();
+			expect(result.success).toBe(false);
+			expect(result.errors[0]?.message).toMatch(/clearing stale journal baselines.*IDB write failure/i);
+			consoleErrorSpy.mockRestore();
+		});
+
+		it('aborts before planning when recording the new destination fingerprint fails', async () => {
+			const context = createEngineContext();
+			context.journal.setMetadata.mockRejectedValueOnce(new Error('IDB write failure'));
+			const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+			const result = await context.engine.sync();
+
+			expect(context.planner.buildPlan).not.toHaveBeenCalled();
+			expect(context.executor.execute).not.toHaveBeenCalled();
+			expect(result.success).toBe(false);
+			expect(result.errors[0]?.message).toMatch(/recording new destination fingerprint.*IDB write failure/i);
+			consoleErrorSpy.mockRestore();
+		});
+
 		it('does not clear or rewrite the fingerprint when the destination is unchanged', async () => {
 			const context = createEngineContext({ bucket: 'same-bucket', syncPrefix: 'vault' });
-			const current = 'provider=aws|region=us-east-1|endpoint=|bucket=same-bucket|prefix=vault';
+			const current = JSON.stringify({
+				provider: 'aws',
+				region: 'us-east-1',
+				endpoint: '',
+				bucket: 'same-bucket',
+				prefix: 'vault',
+			});
 			context.journal.getMetadata.mockResolvedValueOnce(current);
 
 			await context.engine.sync();
@@ -465,14 +545,20 @@ describe('SyncEngine', () => {
 			expect(result.errors[0]?.recoverable).toBe(false);
 		});
 
-		it('allows mass delete-local actions when the destination has a prior successful sync', async () => {
+		it('allows delete-local actions when the destination has a prior successful sync', async () => {
 			const context = createEngineContext();
 			// Stored fingerprint matches current so the planner is invoked; a prior
 			// lastSuccessfulSyncAt signals this destination has been seen before, so
 			// large deletions are legitimate cleanup (e.g. another device wiped files).
 			context.journal.getMetadata.mockImplementation(async (key: string) => {
 				if (key === 'destinationFingerprint') {
-					return 'provider=aws|region=us-east-1|endpoint=|bucket=|prefix=vault';
+					return JSON.stringify({
+						provider: 'aws',
+						region: 'us-east-1',
+						endpoint: '',
+						bucket: '',
+						prefix: 'vault',
+					});
 				}
 				if (key === 'lastSuccessfulSyncAt') {
 					return 1_700_000_000_000;
@@ -486,31 +572,67 @@ describe('SyncEngine', () => {
 			expect(context.executor.execute).toHaveBeenCalledTimes(1);
 		});
 
-		it('does not block when delete-local count is below the absolute threshold and the ratio is small', async () => {
+		it('blocks even a single delete-local on a destination with no prior successful sync', async () => {
+			// Without baselines, the decision table cannot legitimately produce any
+			// delete-local action (deletion requires `L= / R0 + hasBaseline`).  So any
+			// delete on a never-synced destination signals a bug and must be refused
+			// regardless of how small it is.
 			const context = createEngineContext();
-			// 3 deletions inside a 100-action plan — both well under the absolute and
-			// ratio thresholds, so the guard should let the plan proceed.
 			const plan: SyncPlanItem[] = [
-				...createDeletePlan(3),
-				...Array.from({ length: 97 }, (_, i) => createPlanItem(`notes/upload-${i}.md`, 'upload')),
+				...createDeletePlan(1),
+				...Array.from({ length: 99 }, (_, i) => createPlanItem(`notes/upload-${i}.md`, 'upload')),
 			];
 			context.planner.buildPlan.mockResolvedValueOnce(plan);
-
-			await context.engine.sync();
-
-			expect(context.executor.execute).toHaveBeenCalledTimes(1);
-		});
-
-		it('blocks when the plan is dominated by delete-local even on small vaults', async () => {
-			const context = createEngineContext();
-			// 5 deletes in a 5-item plan — below the absolute threshold but 100% of the plan.
-			context.planner.buildPlan.mockResolvedValueOnce(createDeletePlan(5));
 
 			const result = await context.engine.sync();
 
 			expect(context.executor.execute).not.toHaveBeenCalled();
 			expect(result.success).toBe(false);
 			expect(result.errors[0]?.message).toMatch(/destructive plan/i);
+		});
+
+		it('does not block plans without any delete-local actions', async () => {
+			const context = createEngineContext();
+			context.planner.buildPlan.mockResolvedValueOnce([
+				createPlanItem('notes/a.md', 'upload'),
+				createPlanItem('notes/b.md', 'download'),
+			]);
+
+			await context.engine.sync();
+
+			expect(context.executor.execute).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not block when the plan is empty', async () => {
+			const context = createEngineContext();
+			context.planner.buildPlan.mockResolvedValueOnce([]);
+
+			await context.engine.sync();
+
+			expect(context.executor.execute).toHaveBeenCalledTimes(1);
+		});
+
+		it('returns a fully populated blocked SyncResult shape (zeroed counters, single error)', async () => {
+			const context = createEngineContext();
+			context.planner.buildPlan.mockResolvedValueOnce(createDeletePlan(50));
+
+			const result = await context.engine.sync();
+
+			expect(result).toMatchObject({
+				success: false,
+				filesUploaded: 0,
+				filesDownloaded: 0,
+				filesDeleted: 0,
+				filesAdopted: 0,
+				filesForgotten: 0,
+				conflicts: [],
+			});
+			expect(result.errors).toHaveLength(1);
+			expect(result.errors[0]).toMatchObject({
+				path: '',
+				action: 'delete-local',
+				recoverable: false,
+			});
 		});
 	});
 

--- a/tests/sync/SyncEngine.test.ts
+++ b/tests/sync/SyncEngine.test.ts
@@ -48,7 +48,9 @@ interface MockExecutor {
 }
 
 interface MockJournal {
-	setMetadata: jest.Mock<Promise<void>, [string, number]>;
+	setMetadata: jest.Mock<Promise<void>, [string, number | string]>;
+	getMetadata: jest.Mock<Promise<string | number | undefined>, [string]>;
+	clear: jest.Mock<Promise<void>, []>;
 }
 
 interface MockChangeTracker {
@@ -136,6 +138,8 @@ function createEngineContext(overrides: Partial<S3SyncBackupSettings> = {}): Eng
 	const s3Provider: MockS3Provider = { kind: 's3-provider' };
 	const journal: MockJournal = {
 		setMetadata: jest.fn().mockResolvedValue(undefined),
+		getMetadata: jest.fn().mockResolvedValue(undefined),
+		clear: jest.fn().mockResolvedValue(undefined),
 	};
 	const pathCodec: MockPathCodec = {
 		updatePrefix: jest.fn(),
@@ -330,7 +334,9 @@ describe('SyncEngine', () => {
 
 			await context.engine.sync();
 
-			expect(context.journal.setMetadata).not.toHaveBeenCalled();
+			// Note: setMetadata may still be called to record the destination fingerprint;
+			// only the lastSuccessfulSyncAt key must be skipped on failure.
+			expect(context.journal.setMetadata).not.toHaveBeenCalledWith('lastSuccessfulSyncAt', expect.anything());
 		});
 
 		it('wraps an unexpected planner Error into a failed SyncResult', async () => {
@@ -374,6 +380,58 @@ describe('SyncEngine', () => {
 
 			nowSpy.mockRestore();
 			consoleErrorSpy.mockRestore();
+		});
+	});
+
+	/**
+	 * Covers SyncEngine's destination-change detection: when the sync journal was built
+	 * against a different S3 destination (bucket / endpoint / region / prefix / provider),
+	 * baselines from the old destination would mis-classify untouched local files as
+	 * "remotely deleted" and trigger mass `delete-local` actions. The engine must detect
+	 * the mismatch via a stored destination fingerprint and clear the stale baselines
+	 * before planning runs.
+	 */
+	describe('destination fingerprint', () => {
+		it('records the current destination fingerprint on the first sync', async () => {
+			const context = createEngineContext({
+				provider: 'aws',
+				region: 'us-east-1',
+				endpoint: '',
+				bucket: 'my-bucket',
+				syncPrefix: 'vault',
+			});
+
+			await context.engine.sync();
+
+			const expected = 'provider=aws|region=us-east-1|endpoint=|bucket=my-bucket|prefix=vault';
+			expect(context.journal.setMetadata).toHaveBeenCalledWith('destinationFingerprint', expected);
+			expect(context.journal.clear).not.toHaveBeenCalled();
+		});
+
+		it('clears stale baselines and records the new fingerprint when the destination changes', async () => {
+			const context = createEngineContext({ bucket: 'new-bucket', syncPrefix: 'vault' });
+			context.journal.getMetadata.mockResolvedValueOnce('provider=aws|region=us-east-1|endpoint=|bucket=old-bucket|prefix=vault');
+
+			await context.engine.sync();
+
+			expect(context.journal.clear).toHaveBeenCalledTimes(1);
+			const expected = 'provider=aws|region=us-east-1|endpoint=|bucket=new-bucket|prefix=vault';
+			expect(context.journal.setMetadata).toHaveBeenCalledWith('destinationFingerprint', expected);
+			// Clear must happen before the planner runs so stale baselines cannot drive a destructive plan.
+			expect(context.journal.clear.mock.invocationCallOrder[0]).toBeLessThan(
+				context.planner.buildPlan.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+			);
+		});
+
+		it('does not clear or rewrite the fingerprint when the destination is unchanged', async () => {
+			const context = createEngineContext({ bucket: 'same-bucket', syncPrefix: 'vault' });
+			const current = 'provider=aws|region=us-east-1|endpoint=|bucket=same-bucket|prefix=vault';
+			context.journal.getMetadata.mockResolvedValueOnce(current);
+
+			await context.engine.sync();
+
+			expect(context.journal.clear).not.toHaveBeenCalled();
+			expect(context.journal.setMetadata).not.toHaveBeenCalledWith('destinationFingerprint', expect.anything());
 		});
 	});
 

--- a/tests/sync/SyncEngine.test.ts
+++ b/tests/sync/SyncEngine.test.ts
@@ -436,6 +436,85 @@ describe('SyncEngine', () => {
 	});
 
 	/**
+	 * Covers SyncEngine's plan-time safety guard: when a planner output contains an
+	 * unusually high number of `delete-local` actions and the destination has no prior
+	 * successful sync recorded, the engine must refuse to execute and surface a clear
+	 * error.  This is the belt-and-braces backstop against future bugs that would
+	 * otherwise produce a destructive plan slipping past the destination-fingerprint
+	 * invalidation.
+	 */
+	describe('destructive plan guard', () => {
+		function createDeletePlan(count: number): SyncPlanItem[] {
+			return Array.from({ length: count }, (_, i) => ({
+				path: `notes/file-${i}.md`,
+				action: 'delete-local' as const,
+				reason: 'baseline says remotely deleted',
+			}));
+		}
+
+		it('blocks execution when a new destination produces many delete-local actions', async () => {
+			const context = createEngineContext();
+			context.planner.buildPlan.mockResolvedValueOnce(createDeletePlan(50));
+
+			const result = await context.engine.sync();
+
+			expect(context.executor.execute).not.toHaveBeenCalled();
+			expect(result.success).toBe(false);
+			expect(result.errors).toHaveLength(1);
+			expect(result.errors[0]?.message).toMatch(/destructive plan/i);
+			expect(result.errors[0]?.recoverable).toBe(false);
+		});
+
+		it('allows mass delete-local actions when the destination has a prior successful sync', async () => {
+			const context = createEngineContext();
+			// Stored fingerprint matches current so the planner is invoked; a prior
+			// lastSuccessfulSyncAt signals this destination has been seen before, so
+			// large deletions are legitimate cleanup (e.g. another device wiped files).
+			context.journal.getMetadata.mockImplementation(async (key: string) => {
+				if (key === 'destinationFingerprint') {
+					return 'provider=aws|region=us-east-1|endpoint=|bucket=|prefix=vault';
+				}
+				if (key === 'lastSuccessfulSyncAt') {
+					return 1_700_000_000_000;
+				}
+				return undefined;
+			});
+			context.planner.buildPlan.mockResolvedValueOnce(createDeletePlan(50));
+
+			await context.engine.sync();
+
+			expect(context.executor.execute).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not block when delete-local count is below the absolute threshold and the ratio is small', async () => {
+			const context = createEngineContext();
+			// 3 deletions inside a 100-action plan — both well under the absolute and
+			// ratio thresholds, so the guard should let the plan proceed.
+			const plan: SyncPlanItem[] = [
+				...createDeletePlan(3),
+				...Array.from({ length: 97 }, (_, i) => createPlanItem(`notes/upload-${i}.md`, 'upload')),
+			];
+			context.planner.buildPlan.mockResolvedValueOnce(plan);
+
+			await context.engine.sync();
+
+			expect(context.executor.execute).toHaveBeenCalledTimes(1);
+		});
+
+		it('blocks when the plan is dominated by delete-local even on small vaults', async () => {
+			const context = createEngineContext();
+			// 5 deletes in a 5-item plan — below the absolute threshold but 100% of the plan.
+			context.planner.buildPlan.mockResolvedValueOnce(createDeletePlan(5));
+
+			const result = await context.engine.sync();
+
+			expect(context.executor.execute).not.toHaveBeenCalled();
+			expect(result.success).toBe(false);
+			expect(result.errors[0]?.message).toMatch(/destructive plan/i);
+		});
+	});
+
+	/**
 	 * Covers SyncEngine's runtime configuration updates, verifying the path codec,
 	 * planner settings, and executor debug flag all reflect the latest settings snapshot.
 	 */


### PR DESCRIPTION
Fixes #70 · Linear CLO-3

## Summary

Closes the data-loss path described in #70: a vault pointed at a new bucket / endpoint / region / sync prefix / provider used to reuse baselines from the previous destination, which the planner then interpreted as "every file was deleted remotely → trash it locally."

The fix is two independent layers; either one alone closes the reported bug, but both together also harden against future planner regressions.

## Layer 1 — Destination fingerprint (commit `79644ff`)

- New `src/sync/DestinationFingerprint.ts` computes a deterministic string fingerprint from `{ provider, region, endpoint, bucket, normalizedSyncPrefix }`. Credential fields are intentionally excluded so IAM-key rotation does not invalidate the journal.
- `SyncEngine.sync()` now reconciles the fingerprint at the very start of every cycle (before the planner runs):
  - If the stored fingerprint matches the current one → continue.
  - If it differs → `journal.clear()` to wipe stale `stateRecords` + `conflicts`, then record the new fingerprint so future destination changes remain detectable.
  - If absent → first sync against any destination; just record the fingerprint.
- The cleared-and-replanned path naturally results in `L+ / R0 → upload` for every file (a fresh upload against the new destination), which is the intended behaviour.

## Layer 2 — Mass-delete plan guard (commit `a98d953`)

- After the planner builds the plan, `SyncEngine` now inspects the `delete-local` action count. The plan is refused (returning a non-recoverable `SyncResult` error) when **all** of the following hold:
  - `delete-local` count exceeds an absolute threshold (>10) **or** at least half the plan items are `delete-local` (catches small vaults the absolute threshold would miss).
  - The journal has no `lastSuccessfulSyncAt` for the current destination — i.e. this destination has never been confirmed safe.
- This is a backstop: with Layer 1 working correctly, the journal is cleared on destination change so the plan cannot contain mass deletions in the first place. Layer 2 catches future bugs that would otherwise emit a destructive plan against an unseen destination.
- The user-visible error message is explicit about what was refused and what to do next (verify settings or reset the journal).

## Test plan

- [x] `npm run test:unit` — 569 tests pass (added 8 + 7 new tests for the two layers).
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean.

### New / updated tests

- `tests/sync/DestinationFingerprint.test.ts` — 8 cases covering stability, sensitivity to each destination field, prefix normalisation, and credential-field exclusion.
- `tests/sync/SyncEngine.test.ts`:
  - `destination fingerprint` block — first-sync recording, mismatch → clear + rewrite, match → no-op.
  - `destructive plan guard` block — blocks new destination with mass deletes, allows mass deletes when a prior successful sync is recorded, allows small delete counts in mixed plans, blocks 100 %-delete plans on small vaults.
  - Tightened existing `does not persist lastSuccessfulSyncAt when the executor returns a failed result` assertion (was overly broad against `setMetadata`).

## Out of scope

- Journal migration for existing installs (the destination-fingerprint logic absorbs this on first sync after upgrade — old baselines either match the current destination and are kept, or are detected as stale and wiped).
- Surfacing a notice / modal when the journal is reset; the resulting sync is a normal "upload all files" and the existing status-bar feedback is sufficient.