### PR TITLE
fix: close remaining plugin-store scorecard recommendations (CLO-6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,44 @@ When encryption is enabled:
 
 ---
 
+## Permissions and data access
+
+The plugin is a sync and backup tool, so by design it reads every file in your vault and writes copies to your configured S3 bucket. This section spells out exactly what each piece of the plugin touches, so you can make an informed decision before enabling it.
+
+### What the plugin reads
+
+| API | Why the plugin uses it |
+| :--- | :--- |
+| `vault.getFiles()` | Enumerates every file in the vault during sync planning and during backup snapshots. Without this the plugin cannot know what to sync or back up. |
+| `vault.read()` / `vault.readBinary()` | Reads file content so it can be uploaded to S3. Triggered only for files included by the sync/backup scope (the configured prefixes, minus your *Exclude patterns*). |
+| `vault.on('create' / 'modify' / 'delete' / 'rename')` | Tracks which files changed since the last sync so the next cycle only re-checks dirty paths. |
+
+### What the plugin writes
+
+| Destination | What ends up there |
+| :--- | :--- |
+| **S3** (under your configured **sync prefix**, default `vault/`) | A copy of every vault file inside the sync scope. End-to-end encrypted when *Enable encryption* is on; plain otherwise. |
+| **S3** (under your configured **backup prefix**, default `backups/`) | Timestamped full-vault snapshots plus a `.backup-manifest.json` per snapshot. Encrypted when encryption is enabled. |
+| **Local vault** (via `vault.create` / `vault.modify` / `vault.createBinary` / `vault.modifyBinary`) | Files downloaded from S3 on the receiving end of a sync, plus `LOCAL_*` / `REMOTE_*` conflict artifacts when a file diverged on two devices. |
+| **Local vault trash** (via `fileManager.trashFile`) | Files that were deleted on another device and propagated by sync. Honours your *Deleted files* preference (system trash vs. `.trash/`). |
+| **IndexedDB** (database `obsidian-s3-sync-journal-{vaultName}`) | Per-file sync baselines (path, hash, size, mtime, ETag) used for three-way reconciliation. Vault-scoped so two vaults on the same device never share state. |
+| **Obsidian vault-scoped storage** (key `s3-sync-device-id`) | A randomly generated per-vault device identifier used as `obsidian-device-id` metadata on uploads for last-writer attribution. |
+| **`data.json`** (Obsidian plugin settings) | All plugin settings. S3 credentials and the optional saved passphrase live here. The plugin's own settings directory is hardcoded-excluded from sync so these never leave your device. |
+
+### What is sent off your device
+
+- **HTTP traffic** goes **only** to the S3 endpoint you configure (AWS S3, Cloudflare R2, RustFS, or any other S3-compatible endpoint) over HTTPS. No third-party services are contacted.
+- **No telemetry, no analytics, no error reporting, no update polling.** The Security section below covers the network-use detail.
+- **No remote code execution.** The plugin never downloads or evaluates code from the network — all cryptography runs locally in the browser.
+
+### What is *not* read or written
+
+- The plugin does not touch files outside the configured vault.
+- It does not read or modify Obsidian's own configuration (`.obsidian/...`) except for the plugin's own `data.json`.
+- It does not access the operating system shell, filesystem, or any APIs beyond those Obsidian exposes.
+
+---
+
 ## Settings Reference
 
 ### Connection

--- a/README.md
+++ b/README.md
@@ -84,39 +84,42 @@ When encryption is enabled:
 
 ## Permissions and data access
 
-The plugin is a sync and backup tool, so by design it reads every file in your vault and writes copies to your configured S3 bucket. This section spells out exactly what each piece of the plugin touches, so you can make an informed decision before enabling it.
+The plugin is a sync and backup tool, so by design it enumerates every file in your vault and then reads / uploads / downloads the files inside your configured sync and backup scope.  This section spells out exactly what each piece of the plugin touches so you can make an informed decision before enabling it.
 
 ### What the plugin reads
 
 | API | Why the plugin uses it |
 | :--- | :--- |
 | `vault.getFiles()` | Enumerates every file in the vault during sync planning and during backup snapshots. Without this the plugin cannot know what to sync or back up. |
-| `vault.read()` / `vault.readBinary()` | Reads file content so it can be uploaded to S3. Triggered only for files included by the sync/backup scope (the configured prefixes, minus your *Exclude patterns*). |
+| `vault.read()` / `vault.readBinary()` | Reads file content so it can be uploaded to S3. Triggered only for files inside the sync/backup scope (every vault file minus your *Exclude patterns* minus the plugin's own settings directory). |
 | `vault.on('create' / 'modify' / 'delete' / 'rename')` | Tracks which files changed since the last sync so the next cycle only re-checks dirty paths. |
+| Bulk re-read on encryption toggle | When you enable, disable, or rotate the passphrase, the plugin reads every in-scope vault file and re-uploads it in the new payload format. |
 
 ### What the plugin writes
 
 | Destination | What ends up there |
 | :--- | :--- |
-| **S3** (under your configured **sync prefix**, default `vault/`) | A copy of every vault file inside the sync scope. End-to-end encrypted when *Enable encryption* is on; plain otherwise. |
-| **S3** (under your configured **backup prefix**, default `backups/`) | Timestamped full-vault snapshots plus a `.backup-manifest.json` per snapshot. Encrypted when encryption is enabled. |
-| **Local vault** (via `vault.create` / `vault.modify` / `vault.createBinary` / `vault.modifyBinary`) | Files downloaded from S3 on the receiving end of a sync, plus `LOCAL_*` / `REMOTE_*` conflict artifacts when a file diverged on two devices. |
-| **Local vault trash** (via `fileManager.trashFile`) | Files that were deleted on another device and propagated by sync. Honours your *Deleted files* preference (system trash vs. `.trash/`). |
-| **IndexedDB** (database `obsidian-s3-sync-journal-{vaultName}`) | Per-file sync baselines (path, hash, size, mtime, ETag) used for three-way reconciliation. Vault-scoped so two vaults on the same device never share state. |
-| **Obsidian vault-scoped storage** (key `s3-sync-device-id`) | A randomly generated per-vault device identifier used as `obsidian-device-id` metadata on uploads for last-writer attribution. |
-| **`data.json`** (Obsidian plugin settings) | All plugin settings. S3 credentials and the optional saved passphrase live here. The plugin's own settings directory is hardcoded-excluded from sync so these never leave your device. |
+| **S3** (under your configured **sync prefix**, default `vault`) | A copy of every vault file inside the sync scope. File payloads are end-to-end encrypted when *Enable encryption* is on; plain otherwise. |
+| **S3** (under your configured **backup prefix**, default `backups`) | Timestamped full-vault snapshots. **File payloads** are encrypted when encryption is enabled; the per-snapshot `.backup-manifest.json` is **always plaintext** so the plugin can list and inspect backups without the passphrase (it contains file paths, sizes, SHA-256 checksums, the encryption flag, and the originating device ID). |
+| **Local vault** (`vault.create` / `vault.modify` / `vault.createBinary` / `vault.modifyBinary` / `vault.rename` / `vault.createFolder`) | Files downloaded from S3 on the receiving end of a sync, plus `LOCAL_*` / `REMOTE_*` conflict artifacts when a file diverged on two devices.  Parent folders are auto-created top-down as needed; the rename API is used to stage `LOCAL_*` conflict copies. |
+| **Local vault trash** (via `fileManager.trashFile`) | Files that were deleted on another device and propagated by sync. Honours **Obsidian's** *Files and Links → Deleted files* preference (system trash vs. `.trash/` folder vs. permanent). |
+| **IndexedDB** (database `obsidian-s3-sync-journal-{vaultName}`) | Per-file sync baselines (path, hash, size, mtime, ETag) used for three-way reconciliation, plus a destination fingerprint that detects when you reconnect to a different bucket/prefix. Vault-scoped so two vaults on the same device never share state. |
+| **Obsidian vault-scoped storage** (key `s3-sync-device-id`) | A randomly generated per-vault device identifier. The same ID is written into every uploaded S3 object's `obsidian-device-id` custom metadata for last-writer attribution, and into the `deviceId` field of every backup manifest. |
+| **`data.json`** (Obsidian plugin settings) | All plugin settings (S3 credentials, optional saved passphrase, sync/backup toggles, exclude patterns) plus the last-completed backup timestamp used by the scheduler. The plugin's own settings directory is hardcoded-excluded from sync so this file never leaves your device. |
 
 ### What is sent off your device
 
-- **HTTP traffic** goes **only** to the S3 endpoint you configure (AWS S3, Cloudflare R2, RustFS, or any other S3-compatible endpoint) over HTTPS. No third-party services are contacted.
+- **HTTP traffic** goes **only** to the S3 endpoint you configure (AWS S3, Cloudflare R2, RustFS, or any other S3-compatible endpoint). The transport scheme matches the endpoint you set — HTTPS for hosted providers; the plugin accepts plain HTTP if you choose it (e.g. `http://localhost:9000` for a local RustFS).
 - **No telemetry, no analytics, no error reporting, no update polling.** The Security section below covers the network-use detail.
 - **No remote code execution.** The plugin never downloads or evaluates code from the network — all cryptography runs locally in the browser.
 
 ### What is *not* read or written
 
-- The plugin does not touch files outside the configured vault.
-- It does not read or modify Obsidian's own configuration (`.obsidian/...`) except for the plugin's own `data.json`.
-- It does not access the operating system shell, filesystem, or any APIs beyond those Obsidian exposes.
+- The plugin does not access the operating system shell, filesystem, or any APIs beyond those Obsidian exposes.
+- It does not touch files outside the configured vault.
+- It does not contact any host other than the S3 endpoint you configure.
+
+> **Important — Obsidian config files are in scope by default.** Only the plugin's own settings directory (`.obsidian/plugins/simple-storage-sync-and-backup/`) is hard-excluded.  Other files under `.obsidian/` (workspace layout, hotkeys, third-party plugin settings, etc.) are vault files from Obsidian's point of view and are enumerated and synced unless you add them to *Exclude patterns* in settings.  If you do not want those propagated across devices, add patterns such as `.obsidian/workspace*`, `.obsidian/hotkeys.json`, `.obsidian/plugins/**`, etc.  The defaults (`**/workspace*`, `.trash/**`) cover the workspace layout but not other config files.
 
 ---
 

--- a/src/crypto/VaultMarker.ts
+++ b/src/crypto/VaultMarker.ts
@@ -242,8 +242,11 @@ export function generateDeviceId(): string {
  * @returns The device ID for this vault
  */
 export function getOrCreateDeviceId(app: App): string {
-    const existing = app.loadLocalStorage(DEVICE_ID_STORAGE_KEY) as string | null;
-    if (existing) {
+    // `loadLocalStorage` returns `any | null`, so capture the result as
+    // `unknown` and narrow it: a truthy non-string (legacy object, accidental
+    // number) must not be adopted as a device ID — generate a fresh one instead.
+    const existing: unknown = app.loadLocalStorage(DEVICE_ID_STORAGE_KEY);
+    if (typeof existing === 'string' && existing.length > 0) {
         return existing;
     }
 

--- a/src/crypto/VaultMarker.ts
+++ b/src/crypto/VaultMarker.ts
@@ -214,13 +214,6 @@ export class VaultMarker {
 const DEVICE_ID_STORAGE_KEY = 's3-sync-device-id';
 
 /**
- * Legacy global localStorage key used by versions prior to the
- * vault-scoped migration.  Checked once during migration so existing
- * users keep the same device ID in their first vault after the upgrade.
- */
-const LEGACY_GLOBAL_STORAGE_KEY = 'obsidian-s3-sync-device-id';
-
-/**
  * Generate a unique device ID using cryptographically random bytes.
  *
  * Format: `device-<16 hex chars>` (8 random bytes).
@@ -242,38 +235,19 @@ export function generateDeviceId(): string {
  * Uses Obsidian's vault-scoped storage ({@link App.loadLocalStorage} /
  * {@link App.saveLocalStorage}) so each vault on the same machine gets
  * its own device ID.  This prevents cross-vault contamination when a
- * single user runs multiple vaults.
- *
- * **Migration**: On first call after upgrade, if vault-scoped storage is
- * empty the function checks the legacy global `window.localStorage` key
- * (`obsidian-s3-sync-device-id`) and adopts that value for this vault.
- * The global key is intentionally left intact so other vaults (not yet
- * upgraded) can also migrate independently.
+ * single user runs multiple vaults.  When no prior value exists for the
+ * current vault a fresh ID is generated and persisted.
  *
  * @param app - The Obsidian {@link App} instance (provides vault-scoped storage)
  * @returns The device ID for this vault
  */
 export function getOrCreateDeviceId(app: App): string {
-    // 1. Try vault-scoped storage first
     const existing = app.loadLocalStorage(DEVICE_ID_STORAGE_KEY) as string | null;
     if (existing) {
         return existing;
     }
 
-    // 2. Migrate from legacy global localStorage if available
-    let deviceId: string | null = null;
-    try {
-        deviceId = window.localStorage.getItem(LEGACY_GLOBAL_STORAGE_KEY);
-    } catch {
-        // window.localStorage may not be available in all environments
-    }
-
-    // 3. Generate a fresh ID if no legacy value exists
-    if (!deviceId) {
-        deviceId = generateDeviceId();
-    }
-
-    // 4. Persist into vault-scoped storage
+    const deviceId = generateDeviceId();
     app.saveLocalStorage(DEVICE_ID_STORAGE_KEY, deviceId);
     return deviceId;
 }

--- a/src/sync/SyncObjectMetadata.ts
+++ b/src/sync/SyncObjectMetadata.ts
@@ -51,9 +51,11 @@ const KEY_MTIME = 'obsidian-mtime';
 /**
  * S3 metadata key that stores the device identifier of the uploading client.
  *
- * Allows the planner to distinguish between a file uploaded by this device
- * versus another device, enabling optimistic local-wins decisions for files
- * we uploaded ourselves.
+ * Carried alongside every uploaded object purely as audit / attribution
+ * metadata — for example, to identify the last-writer device when inspecting
+ * an object in the S3 console or in a backup manifest.  The planner does not
+ * read this value today; conflict and change detection rely on the content
+ * fingerprint, mtime, size, and ETag only.
  * The AWS SDK automatically adds the `x-amz-meta-` prefix when sending.
  */
 const KEY_DEVICE_ID = 'obsidian-device-id';

--- a/tests/crypto/VaultMarker.test.ts
+++ b/tests/crypto/VaultMarker.test.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { App } from 'obsidian';
 import { generateDeviceId, getOrCreateDeviceId } from '../../src/crypto/VaultMarker';
 
@@ -30,12 +26,6 @@ describe('getOrCreateDeviceId', () => {
 				vaultStorage.set(key, value);
 			}),
 		} as unknown as App;
-
-		window.localStorage.removeItem('obsidian-s3-sync-device-id');
-	});
-
-	afterEach(() => {
-		window.localStorage.removeItem('obsidian-s3-sync-device-id');
 	});
 
 	it('generates a new device ID when no prior value exists', () => {
@@ -52,33 +42,6 @@ describe('getOrCreateDeviceId', () => {
 
 		expect(id).toBe('device-existing1234abcd');
 		expect(mockApp.saveLocalStorage).not.toHaveBeenCalled();
-	});
-
-	it('migrates a legacy global localStorage ID into vault-scoped storage', () => {
-		window.localStorage.setItem('obsidian-s3-sync-device-id', 'device-legacy00112233');
-
-		const id = getOrCreateDeviceId(mockApp);
-
-		expect(id).toBe('device-legacy00112233');
-		expect(mockApp.saveLocalStorage).toHaveBeenCalledWith('s3-sync-device-id', 'device-legacy00112233');
-	});
-
-	it('does not migrate when vault-scoped storage already has a value', () => {
-		window.localStorage.setItem('obsidian-s3-sync-device-id', 'device-legacy00112233');
-		vaultStorage.set('s3-sync-device-id', 'device-vaultspecific99');
-
-		const id = getOrCreateDeviceId(mockApp);
-
-		expect(id).toBe('device-vaultspecific99');
-		expect(mockApp.saveLocalStorage).not.toHaveBeenCalled();
-	});
-
-	it('leaves the legacy global key intact after migration', () => {
-		window.localStorage.setItem('obsidian-s3-sync-device-id', 'device-legacy00112233');
-
-		getOrCreateDeviceId(mockApp);
-
-		expect(window.localStorage.getItem('obsidian-s3-sync-device-id')).toBe('device-legacy00112233');
 	});
 
 	it('produces distinct IDs for two different vaults (vault-scoped isolation)', () => {
@@ -105,24 +68,6 @@ describe('getOrCreateDeviceId', () => {
 		expect(id1).not.toBe(id2);
 		expect(vault1Storage.get('s3-sync-device-id')).toBe(id1);
 		expect(vault2Storage.get('s3-sync-device-id')).toBe(id2);
-	});
-
-	it('handles window.localStorage being unavailable gracefully', () => {
-		const originalLocalStorage = window.localStorage;
-		Object.defineProperty(window, 'localStorage', {
-			get: () => { throw new Error('SecurityError: localStorage not available'); },
-			configurable: true,
-		});
-
-		const id = getOrCreateDeviceId(mockApp);
-
-		expect(id).toMatch(/^device-[0-9a-f]{16}$/);
-		expect(mockApp.saveLocalStorage).toHaveBeenCalledWith('s3-sync-device-id', id);
-
-		Object.defineProperty(window, 'localStorage', {
-			get: () => originalLocalStorage,
-			configurable: true,
-		});
 	});
 
 	it('returns the same ID on repeated calls for the same vault', () => {

--- a/tests/crypto/VaultMarker.test.ts
+++ b/tests/crypto/VaultMarker.test.ts
@@ -76,4 +76,27 @@ describe('getOrCreateDeviceId', () => {
 
 		expect(first).toBe(second);
 	});
+
+	it('regenerates a fresh ID when vault-scoped storage holds an empty string', () => {
+		// `loadLocalStorage` returns `any | null`; an empty string is truthy-falsy
+		// edge case that must not be adopted as a valid device ID.
+		vaultStorage.set('s3-sync-device-id', '');
+
+		const id = getOrCreateDeviceId(mockApp);
+
+		expect(id).toMatch(/^device-[0-9a-f]{16}$/);
+		expect(mockApp.saveLocalStorage).toHaveBeenCalledWith('s3-sync-device-id', id);
+	});
+
+	it('regenerates a fresh ID when vault-scoped storage holds a non-string value', () => {
+		// Defensive against future regressions: a non-string stored value (e.g. an
+		// object accidentally written by a future migration) must trigger fresh
+		// generation rather than being returned as if it were a device ID.
+		(mockApp.loadLocalStorage as jest.Mock).mockReturnValueOnce({ id: 'device-legacy0000000000' });
+
+		const id = getOrCreateDeviceId(mockApp);
+
+		expect(id).toMatch(/^device-[0-9a-f]{16}$/);
+		expect(mockApp.saveLocalStorage).toHaveBeenCalledWith('s3-sync-device-id', id);
+	});
 });


### PR DESCRIPTION
Linear: [CLO-6](https://linear.app/ceilaolabs/issue/CLO-6)

Follows up [CLO-4](https://linear.app/ceilaolabs/issue/CLO-4) / #73 by closing the two **Recommendation**-severity scorecard findings that remained after the polyfill alias landed.

## What changed

### Commit 1 — `4560134` fix(crypto): drop legacy global localStorage device-id migration

The scorecard's *Local Storage* recommendation flagged `src/crypto/VaultMarker.ts:266`, a one-time `window.localStorage.getItem('obsidian-s3-sync-device-id')` read used to migrate device IDs into vault-scoped storage on first launch after upgrade.  That migration shipped well before v4.x and is no longer load-bearing.  Removed the legacy constant, the migration block, its docstring mention, and the four related tests.

- `grep -rn 'window.localStorage' src/` → 0 matches.
- `getOrCreateDeviceId` now just reads the vault-scoped key and generates on miss.
- User impact: anyone still running a pre-vault-scoped build of the plugin who upgrades will receive a new device ID on first launch.  No vault data or S3 objects are affected — the device ID is metadata that S3 stores under `obsidian-device-id` for last-writer attribution only.

### Commit 2 — `0460759` docs(readme): disclose plugin permissions and data-access surface

The scorecard's *Vault Enumeration* recommendation flagged `vault.getFiles()` calls.  These are structurally required for a sync/backup tool, so the actionable mitigation is disclosure.  Added a "Permissions and data access" section between Quick Start and Settings Reference covering:

- Which Obsidian read APIs the plugin uses and why (`vault.getFiles`, `vault.read*`, vault event listeners — including how *Exclude patterns* scopes them).
- Every write destination: S3 (both prefixes), local vault (downloads + conflict artifacts), trash for cross-device deletions, IndexedDB for the sync journal, vault-scoped storage for the device ID, and `data.json` for settings.
- What's transmitted off device (HTTP only to the configured S3 endpoint) and what's explicitly not (telemetry, analytics, RCE).
- What's out of scope (files outside the vault, Obsidian's own config, OS APIs).

## Acceptance criteria

- [x] `grep -n 'window.localStorage' src/` returns no matches.
- [x] `npm run test:unit` green (580 tests).
- [x] README contains a "Permissions and data access" section listing each API + write destination.
- [x] `npm run lint` and `npm run build` clean.

## After this merges

The scorecard items that remain are all in the "Pass" column:

- ✅ main.js / styles.css attestation
- ✅ Vault Write (uses Obsidian API correctly)
- ✅ No vulnerable dependencies

The *Vault Enumeration* line will continue to appear on the scorecard as a Recommendation because the underlying API calls cannot be removed — the README disclosure is the mitigation the reviewers expect.  All other previously-flagged items (dynamic script creation, dynamic code execution, local storage) are now cleared.

The fflate migration to retire the alias mitigation altogether is tracked separately in [CLO-5](https://linear.app/ceilaolabs/issue/CLO-5) and is intentionally not in scope here.