### PR TITLE
feat(storage): Backblaze B2 compatibility + multi-provider test suite (CLO-10, #78)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,25 +1,54 @@
 # =============================================================================
-# S3 Configuration for Integration Tests
+# S3 Credentials for Integration & E2E Tests — one block per provider
 # =============================================================================
-# Copy this file to .env and fill in your S3-compatible storage credentials.
-# This file is used for running integration tests locally.
+# Copy this file to .env and fill in credentials for the provider(s) you want to
+# test against. Tests run against EVERY provider whose credentials are present
+# and skip the rest, so you can configure just one, several, or all of them.
+#
+# Each provider uses a distinct env-var prefix. To add a new provider, append an
+# entry to TEST_PROVIDERS in tests/helpers/s3-test-utils.ts and mirror the block
+# below with its prefix.
+#
+# Tests create objects under a __test__/ prefix and clean up after themselves.
 #
 # IMPORTANT: Never commit the actual .env file with real credentials!
 # =============================================================================
 
-# S3-compatible endpoint URL
-# For Cloudflare R2: https://<ACCOUNT_ID>.r2.cloudflarestorage.com
-# For AWS S3: Leave empty (SDK uses default)
-# For MinIO: Your MinIO server URL
-S3_URL=""
+# -----------------------------------------------------------------------------
+# Cloudflare R2  (prefix: CF_)
+# -----------------------------------------------------------------------------
+# Endpoint format: https://<ACCOUNT_ID>.r2.cloudflarestorage.com
+CF_URL=""
+CF_BUCKET_NAME=""
+CF_ACCESS_KEY=""
+CF_SECRET_ACCESS_KEY=""
+# R2 ignores the region — use "auto".
+CF_REGION="auto"
 
-# Bucket name to use for tests
-# Tests will create files under __test__/ prefix and clean up after
-S3_BUCKET_NAME=""
+# -----------------------------------------------------------------------------
+# Backblaze B2  (prefix: BB_)
+# -----------------------------------------------------------------------------
+# Endpoint format: https://s3.<REGION>.backblazeb2.com (e.g. s3.us-west-004.backblazeb2.com)
+BB_URL=""
+BB_BUCKET_NAME=""
+BB_ACCESS_KEY=""
+BB_SECRET_ACCESS_KEY=""
+# B2 requires the region baked into the endpoint (e.g. us-west-004).
+BB_REGION=""
 
-# Access credentials
-S3_ACCESS_KEY=""
-S3_SECRET_ACCESS_KEY=""
-
-# Region (use "auto" for Cloudflare R2)
-S3_REGION="auto"
+# -----------------------------------------------------------------------------
+# Future providers (uncomment the matching entry in TEST_PROVIDERS to enable)
+# -----------------------------------------------------------------------------
+# AWS S3  (prefix: AWS_) — leave AWS_URL empty to use the SDK's default endpoint
+# AWS_URL=""
+# AWS_BUCKET_NAME=""
+# AWS_ACCESS_KEY=""
+# AWS_SECRET_ACCESS_KEY=""
+# AWS_REGION="us-east-1"
+#
+# RustFS  (prefix: RUSTFS_) — self-hosted, e.g. http://localhost:9000
+# RUSTFS_URL=""
+# RUSTFS_BUCKET_NAME=""
+# RUSTFS_ACCESS_KEY=""
+# RUSTFS_SECRET_ACCESS_KEY=""
+# RUSTFS_REGION="auto"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -117,12 +117,21 @@ jobs:
     if: needs.check-skip.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     env:
-      # S3 credentials for integration tests (from repository secrets)
-      S3_URL: ${{ secrets.S3_URL }}
-      S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
-      S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
-      S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
-      S3_REGION: ${{ secrets.S3_REGION }}
+      # Per-provider S3 credentials for integration/E2E tests (from repository secrets).
+      # Configure the providers you want CI to exercise; each is independent and
+      # tests skip any provider whose *_URL secret is empty. See .env.sample.
+      # Cloudflare R2
+      CF_URL: ${{ secrets.CF_URL }}
+      CF_BUCKET_NAME: ${{ secrets.CF_BUCKET_NAME }}
+      CF_ACCESS_KEY: ${{ secrets.CF_ACCESS_KEY }}
+      CF_SECRET_ACCESS_KEY: ${{ secrets.CF_SECRET_ACCESS_KEY }}
+      CF_REGION: ${{ secrets.CF_REGION }}
+      # Backblaze B2
+      BB_URL: ${{ secrets.BB_URL }}
+      BB_BUCKET_NAME: ${{ secrets.BB_BUCKET_NAME }}
+      BB_ACCESS_KEY: ${{ secrets.BB_ACCESS_KEY }}
+      BB_SECRET_ACCESS_KEY: ${{ secrets.BB_SECRET_ACCESS_KEY }}
+      BB_REGION: ${{ secrets.BB_REGION }}
     steps:
       - uses: actions/checkout@v6
 
@@ -137,28 +146,16 @@ jobs:
       - name: Run Unit Tests
         run: npm run test:unit -- --coverage
 
-      # Run integration tests (if S3 credentials are configured)
-      # The npm script conditionally loads .env if it exists
+      # Run integration tests against every provider whose credentials are set.
+      # Runs when at least one provider is configured; the suite skips the rest.
       - name: Run Integration Tests
-        if: env.S3_URL != ''
-        env:
-          S3_URL: ${{ secrets.S3_URL }}
-          S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
-          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
-          S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
-          S3_REGION: ${{ secrets.S3_REGION }}
+        if: env.CF_URL != '' || env.BB_URL != ''
         run: npm run test:integration
 
-      # Run E2E pipeline tests (if S3 credentials are configured)
-      # These exercise full sync, encryption, backup, and multi-device workflows
+      # Run E2E pipeline tests against every configured provider.
+      # These exercise full sync, encryption, backup, and multi-device workflows.
       - name: Run E2E Tests
-        if: env.S3_URL != ''
-        env:
-          S3_URL: ${{ secrets.S3_URL }}
-          S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
-          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
-          S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
-          S3_REGION: ${{ secrets.S3_REGION }}
+        if: env.CF_URL != '' || env.BB_URL != ''
         run: npm run test:e2e
 
       # Upload coverage report as artifact for later review

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-**Obsidian S3 Sync + Backup** — An Obsidian community plugin that provides bi-directional vault synchronization and scheduled backups for S3-compatible storage (AWS S3, Cloudflare R2, RustFS) with optional end-to-end encryption.
+**Obsidian S3 Sync + Backup** — An Obsidian community plugin that provides bi-directional vault synchronization and scheduled backups for S3-compatible storage (AWS S3, Cloudflare R2, Backblaze B2, RustFS) with optional end-to-end encryption.
 
 **Plugin ID:** `simple-storage-sync-and-backup`
 
@@ -154,10 +154,17 @@ npm run dev             # Development build with watch
 npm run build           # Production build (tsc + esbuild)
 npm run lint            # Run ESLint (mandatory after every change)
 npm run test:unit       # Run unit tests
-npm run test:integration # Run integration tests (requires .env with S3 creds)
+npm run test:integration # Per-provider integration tests (requires .env; see .env.sample)
+npm run test:e2e        # Per-provider end-to-end pipeline tests (requires .env)
 npm run test:coverage   # Unit tests with coverage report
 npm run test:watch      # Watch mode
 ```
+
+**Multi-provider tests:** Integration/E2E tests run against every S3 provider whose
+credentials are configured in `.env` and skip the rest. Each provider uses its own
+env-var prefix (`CF_` = Cloudflare R2, `BB_` = Backblaze B2). The matrix lives in
+`TEST_PROVIDERS` (`tests/helpers/s3-test-utils.ts`); see `.env.sample` and
+CONTRIBUTING.md for how to add a provider.
 
 ### Linting Rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,25 +189,42 @@ Tests are essential. We maintain a **75% minimum coverage threshold** enforced b
 
 **Test file naming**: `tests/<domain>/<ModuleName>.test.ts`
 
-### Integration Tests
+### Integration & E2E Tests
 
--   **Location**: `tests/**/*.integration.test.ts`
--   **Focus**: Real S3 operations against a live bucket
--   **Config**: Requires `.env` file with S3 credentials
+-   **Location**: `tests/**/*.integration.test.ts` (raw S3 + `S3Provider` operations)
+    and `tests/e2e/*.e2e.test.ts` (full sync/backup/encryption/multi-device pipelines).
+-   **Focus**: Real S3 operations against live buckets, **per provider**.
+-   **Config**: Requires a `.env` file with credentials for one or more providers.
+
+Integration/E2E tests are **multi-provider**: they run against every provider whose
+credentials are configured (via `describe.each`) and skip the rest. Each provider
+has its own env-var prefix (`CF_` for Cloudflare R2, `BB_` for Backblaze B2, …).
 
 **Setup:**
 1.  Copy `.env.sample` to `.env`.
-2.  Fill in valid S3 credentials:
+2.  Fill in credentials for the provider(s) you want to test. Each provider needs
+    the five prefixed variables — e.g. for Cloudflare R2:
     ```env
-    S3_ENDPOINT=...
-    S3_REGION=...
-    S3_BUCKET=...
-    S3_ACCESS_KEY=...
-    S3_SECRET_KEY=...
+    CF_URL=https://<ACCOUNT_ID>.r2.cloudflarestorage.com
+    CF_BUCKET_NAME=...
+    CF_ACCESS_KEY=...
+    CF_SECRET_ACCESS_KEY=...
+    CF_REGION=auto
     ```
-3.  Run: `npm run test:integration`
+    and for Backblaze B2 (`BB_URL`, `BB_BUCKET_NAME`, `BB_ACCESS_KEY`,
+    `BB_SECRET_ACCESS_KEY`, `BB_REGION`). Configure as many as you like.
+3.  Run: `npm run test:integration` and/or `npm run test:e2e`.
 
-> ⚠️ Integration tests create and delete objects in the specified bucket. Use a dedicated test bucket. Most cloud providers offer generous free tiers well above these limits.
+**Adding a new provider** to the matrix:
+1.  Append an entry to `TEST_PROVIDERS` in `tests/helpers/s3-test-utils.ts`
+    (`{ id, name, envPrefix, provider }`).
+2.  Add the matching credential block to `.env.sample` (and your `.env`).
+3.  If it needs a first-class plugin option, add it to `S3ProviderType` /
+    `S3_PROVIDER_NAMES` in `src/types.ts` and the switches in `src/storage/S3Config.ts`.
+
+> ⚠️ Integration/E2E tests create and delete objects in the specified buckets. Use
+> a dedicated test bucket per provider. Most cloud providers offer generous free
+> tiers well above these limits.
 
 ### Coverage
 
@@ -231,7 +248,7 @@ When filing a bug report on [GitHub Issues](https://github.com/ceilaolabs/obsidi
 3.  **Include:**
     -   Obsidian version and platform (desktop/mobile, OS)
     -   Plugin version
-    -   S3 provider (AWS, R2, RustFS, etc.)
+    -   S3 provider (AWS, R2, Backblaze B2, RustFS, etc.)
     -   Steps to reproduce
     -   Expected vs. actual behavior
     -   Console errors (if any — open DevTools with `Cmd/Ctrl + Shift + I`)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Obsidian S3 Sync + Backup
 
-Vault synchronization and scheduled backups across devices using S3-compatible storage (AWS S3, Cloudflare R2, RustFS, etc.) with optional end-to-end encryption.
+Vault synchronization and scheduled backups across devices using S3-compatible storage (AWS S3, Cloudflare R2, Backblaze B2, RustFS, etc.) with optional end-to-end encryption.
 
 [![Latest Release](https://img.shields.io/github/v/release/ceilaolabs/obsidian-s3-sync-and-backup?sort=semver)](https://github.com/ceilaolabs/obsidian-s3-sync-and-backup/releases/latest)
 ![Obsidian](https://img.shields.io/badge/Obsidian-1.0.0+-purple.svg)
@@ -11,7 +11,7 @@ Vault synchronization and scheduled backups across devices using S3-compatible s
 ## Features
 
 - **Bi-directional Sync** — Three-way reconciliation keeps your vault synchronized across devices via S3. Per-file SHA-256 baselines stored locally in IndexedDB detect changes accurately — no cloud manifest required.
-- **S3-Compatible Storage** — Works with AWS S3, Cloudflare R2, RustFS, and any other S3-compatible endpoint.
+- **S3-Compatible Storage** — Works with AWS S3, Cloudflare R2, Backblaze B2, RustFS, and any other S3-compatible endpoint.
 - **End-to-End Encryption** — Optional XSalsa20-Poly1305 encryption with Argon2id key derivation. Encrypts both synced files and backup snapshots. Passphrase can be remembered for auto-unlock on startup.
 - **Scheduled Backups** — Full vault snapshot backups with configurable intervals (hourly to weekly). Download any backup as a ZIP from settings.
 - **Smart Conflict Resolution** — When the same file changes on two devices while offline, the plugin creates `LOCAL_` and `REMOTE_` copies so you never lose data.
@@ -44,13 +44,13 @@ Vault synchronization and scheduled backups across devices using S3-compatible s
 
 ### 1. Configure S3 Connection
 1. Open **Settings** → **S3 Sync + Backup**.
-2. Select your provider (**AWS S3**, **Cloudflare R2**, **RustFS**, or **Other S3-compatible**).
+2. Select your provider (**AWS S3**, **Cloudflare R2**, **Backblaze B2**, **RustFS**, or **Other S3-compatible**).
 3. Enter your credentials:
-   - **Endpoint URL**: Required for non-AWS providers.
-   - **Region**: Use `auto` for Cloudflare R2.
+   - **Endpoint URL**: Required for non-AWS providers (e.g. `https://s3.<REGION>.backblazeb2.com` for Backblaze B2).
+   - **Region**: Use `auto` for Cloudflare R2; for Backblaze B2 use the region in your endpoint (e.g. `us-west-004`).
    - **Bucket name**: Your S3 bucket.
    - **Access Key ID** & **Secret Access Key**.
-   - **Force Path Style**: Only shown for the **Other S3-compatible** provider — AWS S3, Cloudflare R2, and RustFS each use a fixed addressing mode (path-style for R2/RustFS, virtual-hosted for AWS).
+   - **Force Path Style**: Only shown for the **Other S3-compatible** provider — AWS S3, Cloudflare R2, Backblaze B2, and RustFS each use a fixed addressing mode (path-style for R2/B2/RustFS, virtual-hosted for AWS).
 4. Click **Test Connection** to verify credentials and bucket access.
 
 ### 2. Enable Sync
@@ -129,13 +129,13 @@ The plugin is a sync and backup tool, so by design it enumerates every file in y
 
 | Setting | Description |
 | :--- | :--- |
-| **Provider** | Storage provider: AWS S3, Cloudflare R2, RustFS, or Other S3-compatible. |
-| **Endpoint URL** | S3-compatible endpoint URL. Required for non-AWS providers (e.g., `https://<ACCOUNT_ID>.r2.cloudflarestorage.com` for R2, `http://localhost:9000` for RustFS). Hidden when provider is AWS. |
-| **Region** | AWS region (e.g., `us-east-1`). Use `auto` for Cloudflare R2. |
+| **Provider** | Storage provider: AWS S3, Cloudflare R2, Backblaze B2, RustFS, or Other S3-compatible. |
+| **Endpoint URL** | S3-compatible endpoint URL. Required for non-AWS providers (e.g., `https://<ACCOUNT_ID>.r2.cloudflarestorage.com` for R2, `https://s3.<REGION>.backblazeb2.com` for Backblaze B2, `http://localhost:9000` for RustFS). Hidden when provider is AWS. |
+| **Region** | AWS region (e.g., `us-east-1`). Use `auto` for Cloudflare R2; for Backblaze B2 use the region in your endpoint (e.g., `us-west-004`). |
 | **Bucket** | Name of your S3 bucket. |
 | **Access key ID** | Your S3 access key ID. Displayed as a password field. |
 | **Secret access key** | Your S3 secret access key. Displayed as a password field. |
-| **Force path style** | Use path-style URLs instead of virtual-hosted. Required for some self-hosted S3-compatible endpoints. Only shown for the **Other S3-compatible** provider — AWS, R2, and RustFS each pin a fixed addressing mode internally. |
+| **Force path style** | Use path-style URLs instead of virtual-hosted. Required for some self-hosted S3-compatible endpoints. Only shown for the **Other S3-compatible** provider — AWS, R2, B2, and RustFS each pin a fixed addressing mode internally. |
 | **Test connection** | Verify credentials, bucket access, and required permissions. |
 
 ### Encryption

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -135,9 +135,9 @@ export class S3SyncBackupSettingTab extends PluginSettingTab {
 		// Region
 		new Setting(containerEl)
 			.setName('Region')
-			.setDesc(this.plugin.settings.provider === 'r2' ? 'Use "auto" for Cloudflare R2' : 'AWS region (e.g., us-east-1)')
+			.setDesc(this.getRegionDescription())
 			.addText((text) => {
-				text.setPlaceholder(this.plugin.settings.provider === 'r2' ? 'auto' : 'us-east-1');
+				text.setPlaceholder(this.getRegionPlaceholder());
 				text.setValue(this.plugin.settings.region);
 				text.onChange(async (value) => {
 					this.plugin.settings.region = value;
@@ -227,6 +227,8 @@ export class S3SyncBackupSettingTab extends PluginSettingTab {
 		switch (this.plugin.settings.provider) {
 			case 'r2':
 				return 'Your R2 endpoint URL (https://<ACCOUNT_ID>.r2.cloudflarestorage.com)';
+			case 'b2':
+				return 'Your Backblaze B2 S3 endpoint URL (https://s3.<REGION>.backblazeb2.com)';
 			case 'rustfs':
 				return 'Your RustFS server URL (e.g., http://localhost:9000)';
 			case 'custom':
@@ -249,12 +251,51 @@ export class S3SyncBackupSettingTab extends PluginSettingTab {
 		switch (this.plugin.settings.provider) {
 			case 'r2':
 				return 'https://abc123.r2.cloudflarestorage.com';
+			case 'b2':
+				return 'https://s3.us-west-004.backblazeb2.com';
 			case 'rustfs':
 				return 'http://localhost:9000';
 			case 'custom':
 				return 'https://s3.example.com';
 			default:
 				return '';
+		}
+	}
+
+	/**
+	 * Return a human-readable description for the region field.
+	 *
+	 * The region carries different meaning per provider: Cloudflare R2 ignores it
+	 * (the documented value is `"auto"`), Backblaze B2 requires the region baked
+	 * into its endpoint (e.g. `us-west-004`) because SigV4 signing must match, and
+	 * AWS uses a standard region code.
+	 *
+	 * @returns A localized description string appropriate for the current provider.
+	 */
+	private getRegionDescription(): string {
+		switch (this.plugin.settings.provider) {
+			case 'r2':
+				return 'Use "auto" for Cloudflare R2';
+			case 'b2':
+				return 'Your Backblaze B2 region, matching the endpoint (e.g., us-west-004)';
+			default:
+				return 'AWS region (e.g., us-east-1)';
+		}
+	}
+
+	/**
+	 * Return the placeholder text for the region input field.
+	 *
+	 * @returns A provider-specific example region string.
+	 */
+	private getRegionPlaceholder(): string {
+		switch (this.plugin.settings.provider) {
+			case 'r2':
+				return 'auto';
+			case 'b2':
+				return 'us-west-004';
+			default:
+				return 'us-east-1';
 		}
 	}
 

--- a/src/storage/S3Config.ts
+++ b/src/storage/S3Config.ts
@@ -52,6 +52,14 @@ export function getEndpointForProvider(settings: S3SyncBackupSettings): string |
             }
             throw new Error('Cloudflare R2 requires an endpoint URL (https://<ACCOUNT_ID>.r2.cloudflarestorage.com)');
 
+        case 'b2':
+            // Backblaze B2 exposes an S3-compatible endpoint per region.
+            // Format: https://s3.<REGION>.backblazeb2.com (e.g. s3.us-west-004.backblazeb2.com)
+            if (settings.endpoint) {
+                return settings.endpoint;
+            }
+            throw new Error('Backblaze B2 requires an endpoint URL (https://s3.<REGION>.backblazeb2.com)');
+
         case 'rustfs':
             // RustFS is self-hosted and always requires a custom endpoint URL
             // (e.g., http://localhost:9000 for a local deployment).
@@ -101,6 +109,13 @@ export function shouldForcePathStyle(settings: S3SyncBackupSettings): boolean {
             // R2 works with both, but path-style is more reliable
             return true;
 
+        case 'b2':
+            // Backblaze B2 supports both addressing modes, but path-style is the
+            // more reliable default: it avoids virtual-hosted DNS/SNI edge cases
+            // for buckets whose names are not fully DNS-safe, and works against
+            // the regional S3 endpoint on every B2 account.
+            return true;
+
         case 'aws':
             // AWS prefers virtual-hosted, but respect user setting
             return settings.forcePathStyle;
@@ -112,6 +127,25 @@ export function shouldForcePathStyle(settings: S3SyncBackupSettings): boolean {
         default:
             return settings.forcePathStyle;
     }
+}
+
+/**
+ * Whether a provider's S3 API implements conditional writes
+ * (`If-Match` / `If-None-Match` on `PutObject`).
+ *
+ * The sync engine uses these headers as an optimistic-concurrency guard on every
+ * upload. Most S3-compatible providers honour them, but **Backblaze B2 does not**:
+ * its S3 API returns `501 NotImplemented` ("A header you provided implies
+ * functionality that is not implemented") for any conditional `PutObject`. For
+ * such providers, {@link S3Provider.uploadFile} emulates the guard with a
+ * `HeadObject` pre-check instead of sending the unsupported header.
+ *
+ * @param provider - Provider type from settings.
+ * @returns `true` if native conditional writes can be used, `false` if they must
+ *   be emulated.
+ */
+export function providerSupportsConditionalWrites(provider: S3ProviderType): boolean {
+    return provider !== 'b2';
 }
 
 /**
@@ -141,6 +175,25 @@ export function buildS3ClientConfig(settings: S3SyncBackupSettings): S3ClientCon
             secretAccessKey: settings.secretAccessKey,
         },
         forcePathStyle: shouldForcePathStyle(settings),
+        // Disable the SDK's default flexible-checksum behaviour for portability.
+        //
+        // Since @aws-sdk/client-s3 v3.729.0 the client defaults
+        // `requestChecksumCalculation` to `'WHEN_SUPPORTED'`, which auto-adds
+        // modern integrity headers (`x-amz-checksum-crc32`,
+        // `x-amz-sdk-checksum-algorithm`) to body-bearing requests such as
+        // `PutObject`.  AWS documents that some third-party S3-compatible
+        // services reject these with "A header you provided implies
+        // functionality that is not implemented".  Pinning both knobs to
+        // `'WHEN_REQUIRED'` restricts checksums to operations that mandate them,
+        // keeping uploads portable across every S3-compatible endpoint.
+        //
+        // Note: for the Backblaze B2 incompatibility in issue #78 the *confirmed*
+        // blocker was conditional-write headers, not checksums (B2 accepts CRC32
+        // on plain PutObject) — that is handled separately via the HeadObject
+        // emulation in `S3Provider.uploadFile`.  This setting remains a defensive
+        // measure for providers/regions that do reject the checksum headers.
+        requestChecksumCalculation: 'WHEN_REQUIRED',
+        responseChecksumValidation: 'WHEN_REQUIRED',
         // Route all HTTP traffic through Obsidian's requestUrl API.  This is
         // required because the plugin runs in a browser-like Electron context
         // where native fetch() is blocked by CORS for S3-compatible origins.
@@ -201,6 +254,10 @@ export function validateConnectionSettings(settings: S3SyncBackupSettings): stri
         errors.push('Cloudflare R2 requires an endpoint URL');
     }
 
+    if (settings.provider === 'b2' && !settings.endpoint) {
+        errors.push('Backblaze B2 requires an endpoint URL');
+    }
+
     if (settings.provider === 'rustfs' && !settings.endpoint) {
         errors.push('RustFS requires an endpoint URL');
     }
@@ -233,6 +290,8 @@ export function getProviderDisplayName(provider: S3ProviderType): string {
             return 'AWS S3';
         case 'r2':
             return 'Cloudflare R2';
+        case 'b2':
+            return 'Backblaze B2';
         case 'rustfs':
             return 'RustFS';
         case 'custom':

--- a/src/storage/S3Provider.ts
+++ b/src/storage/S3Provider.ts
@@ -37,7 +37,7 @@ import {
     ListObjectsV2CommandOutput,
 } from '@aws-sdk/client-s3';
 import { PayloadFormat, S3DownloadResult, S3HeadResult, S3ObjectInfo, S3SyncBackupSettings } from '../types';
-import { buildS3ClientConfig, validateConnectionSettings } from './S3Config';
+import { buildS3ClientConfig, providerSupportsConditionalWrites, validateConnectionSettings } from './S3Config';
 
 /**
  * S3Provider class
@@ -537,13 +537,21 @@ export class S3Provider {
      * ETag values must be bare hex strings; this method re-adds the required
      * surrounding quotes before forwarding to the SDK.
      *
+     * **Providers without conditional writes** — Backblaze B2 does not implement
+     * conditional `PutObject` (see {@link providerSupportsConditionalWrites}). For
+     * those providers the guard is emulated with a `HeadObject` pre-check
+     * ({@link checkConditionalPrecondition}) that throws the same
+     * `PreconditionFailed` error before uploading without the header. This closes
+     * most of the concurrency window (a small TOCTOU gap remains between the head
+     * and the put), keeping behaviour identical from the caller's perspective.
+     *
      * @param key - Full S3 key for the destination object.
      * @param content - File bytes or UTF-8 string to upload.
      * @param options - Optional content type string, or an options object with
      *   `contentType`, `ifMatch`, `ifNoneMatch`, and/or `metadata` fields.
      * @returns The ETag of the newly created/updated object (quotes/weak-prefix stripped).
      * @throws {Error} On S3/network error, or if a conditional header is not
-     *   satisfied (HTTP 412 Precondition Failed).
+     *   satisfied (HTTP 412 Precondition Failed) — including the emulated case.
      */
 	async uploadFile(
 		key: string,
@@ -557,22 +565,100 @@ export class S3Provider {
             : content;
 
         const contentType = typeof options === 'string' ? options : options?.contentType;
-		const ifMatch = typeof options === 'string' ? undefined : this.toConditionalEntityTag(options?.ifMatch);
-		const ifNoneMatch = typeof options === 'string' ? undefined : this.toConditionalEntityTag(options?.ifNoneMatch);
+		const rawIfMatch = typeof options === 'string' ? undefined : options?.ifMatch;
+		const rawIfNoneMatch = typeof options === 'string' ? undefined : options?.ifNoneMatch;
 		const metadata = typeof options === 'string' ? undefined : options?.metadata;
+
+		// Decide how to enforce the conditional guard: native headers where the
+		// provider supports them, otherwise a HeadObject pre-check emulation.
+		const hasCondition = Boolean(rawIfMatch || rawIfNoneMatch);
+		const emulateCondition = hasCondition
+			&& !providerSupportsConditionalWrites(this.settings.provider);
+
+		if (emulateCondition) {
+			await this.checkConditionalPrecondition(key, rawIfMatch, rawIfNoneMatch);
+		}
 
         const response = await client.send(new PutObjectCommand({
             Bucket: this.settings.bucket,
             Key: key,
             Body: body,
             ContentType: contentType,
-            IfMatch: ifMatch,
-            IfNoneMatch: ifNoneMatch,
+            IfMatch: emulateCondition ? undefined : this.toConditionalEntityTag(rawIfMatch),
+            IfNoneMatch: emulateCondition ? undefined : this.toConditionalEntityTag(rawIfNoneMatch),
             Metadata: metadata,
         }));
 
 		// Return cleaned ETag (remove quotes and weak prefix)
 		return this.normalizeETag(response.ETag);
+	}
+
+	/**
+	 * Emulate an `If-Match` / `If-None-Match` conditional-write precondition with
+	 * a `HeadObject` pre-check, for providers (e.g. Backblaze B2) that do not
+	 * implement conditional `PutObject`.
+	 *
+	 * Throws a `PreconditionFailed` error (name + HTTP 412 metadata) matching what
+	 * a native conditional write would produce, so callers handle both paths
+	 * identically. Only the forms the sync engine uses are meaningful:
+	 * `ifNoneMatch: '*'` (create-only) and `ifMatch: <etag>` (update-only), but
+	 * the general semantics are honoured.
+	 *
+	 * Note the inherent TOCTOU gap: another writer could change the object between
+	 * this head and the subsequent put. Native conditional writes are atomic and
+	 * do not have this gap; the plugin's planner-level reconciliation is the
+	 * backstop that reconciles any divergence on the next sync.
+	 *
+	 * @param key - Full S3 key being written.
+	 * @param ifMatch - Bare ETag the remote object must currently have, if set.
+	 * @param ifNoneMatch - `'*'` (must be absent) or a bare ETag the remote must
+	 *   NOT currently have, if set.
+	 * @throws {Error} `PreconditionFailed` when the precondition is not satisfied.
+	 */
+	private async checkConditionalPrecondition(
+		key: string,
+		ifMatch?: string,
+		ifNoneMatch?: string,
+	): Promise<void> {
+		const head = await this.headObject(key);
+
+		if (ifNoneMatch) {
+			const conflicts = ifNoneMatch === '*'
+				? head !== null
+				: head !== null && head.etag === this.normalizeETag(ifNoneMatch);
+			if (conflicts) {
+				throw this.createPreconditionFailedError(
+					`Conditional write failed for ${key}: object already exists (If-None-Match).`,
+				);
+			}
+		}
+
+		if (ifMatch) {
+			const expected = this.normalizeETag(ifMatch);
+			if (!head || head.etag !== expected) {
+				throw this.createPreconditionFailedError(
+					`Conditional write failed for ${key}: remote ETag ${head?.etag ?? '<absent>'} `
+						+ `does not match expected ${expected} (If-Match).`,
+				);
+			}
+		}
+	}
+
+	/**
+	 * Build an error mirroring a native S3 `PreconditionFailed` (HTTP 412) so the
+	 * emulated conditional-write path is indistinguishable to callers.
+	 *
+	 * @param message - Human-readable failure description.
+	 * @returns An `Error` with `name = 'PreconditionFailed'` and a 412 `$metadata`.
+	 */
+	private createPreconditionFailedError(message: string): Error {
+		const error = new Error(message) as Error & {
+			name: string;
+			$metadata?: { httpStatusCode: number };
+		};
+		error.name = 'PreconditionFailed';
+		error.$metadata = { httpStatusCode: 412 };
+		return error;
 	}
 
 	/**

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,18 +12,19 @@
 /**
  * Supported S3-compatible storage providers
  */
-export type S3ProviderType = 'aws' | 'r2' | 'rustfs' | 'custom';
+export type S3ProviderType = 'aws' | 'r2' | 'b2' | 'rustfs' | 'custom';
 
 /**
  * Provider display names for UI.
  *
  * Insertion order controls the order entries appear in the settings dropdown
  * (driven by `Object.entries(S3_PROVIDER_NAMES)` in `settings.ts`). The desired
- * order is: AWS S3 → Cloudflare R2 → RustFS → Other S3-compatible.
+ * order is: AWS S3 → Cloudflare R2 → Backblaze B2 → RustFS → Other S3-compatible.
  */
 export const S3_PROVIDER_NAMES: Record<S3ProviderType, string> = {
 	aws: 'AWS S3',
 	r2: 'Cloudflare R2',
+	b2: 'Backblaze B2',
 	rustfs: 'RustFS',
 	custom: 'Other S3-compatible',
 };

--- a/tests/backup/BackupWorkflow.integration.test.ts
+++ b/tests/backup/BackupWorkflow.integration.test.ts
@@ -19,25 +19,22 @@ import {
     ListObjectsV2Command,
 } from '@aws-sdk/client-s3';
 import {
+    TestProvider,
     createTestS3Client,
-    hasS3Credentials,
     getS3Config,
     getTestPrefix,
+    describeEachProvider,
 } from '../helpers/s3-test-utils';
 import { BackupManifest } from '../../src/types';
 
-describe('Backup Workflow Integration Tests', () => {
+describeEachProvider()('Backup Workflow Integration Tests [$name]', (provider: TestProvider) => {
     let client: S3Client;
     let bucket: string;
     let backupPrefix: string;
 
     beforeAll(() => {
-        if (!hasS3Credentials()) {
-            console.warn('⚠️ S3 credentials not configured, skipping integration tests');
-            return;
-        }
-        client = createTestS3Client();
-        bucket = getS3Config().bucket;
+        client = createTestS3Client(provider);
+        bucket = getS3Config(provider).bucket;
         backupPrefix = getTestPrefix('backup');
     });
 
@@ -77,8 +74,6 @@ describe('Backup Workflow Integration Tests', () => {
 
     describe('Backup File Structure', () => {
         it('should create backup folder with timestamp naming', async () => {
-            if (!hasS3Credentials()) return;
-
             const backupName = generateBackupName();
             const testFile = `${backupPrefix}/${backupName}/Notes/test.md`;
 
@@ -98,8 +93,6 @@ describe('Backup Workflow Integration Tests', () => {
         });
 
         it('should maintain complete backup structure with manifest', async () => {
-            if (!hasS3Credentials()) return;
-
             const backupName = generateBackupName() + '-full';
             const files = [
                 { path: 'Notes/readme.md', content: '# Readme' },
@@ -147,8 +140,6 @@ describe('Backup Workflow Integration Tests', () => {
 
     describe('Backup Listing', () => {
         it('should read backup manifest for info display', async () => {
-            if (!hasS3Credentials()) return;
-
             const backupName = generateBackupName() + '-info';
             const manifestKey = `${backupPrefix}/${backupName}/.backup-manifest.json`;
 
@@ -186,8 +177,6 @@ describe('Backup Workflow Integration Tests', () => {
 
     describe('Backup Cleanup (Retention)', () => {
         it('should delete entire backup folder', async () => {
-            if (!hasS3Credentials()) return;
-
             const backupName = generateBackupName() + '-retention';
             const backupPath = `${backupPrefix}/${backupName}`;
 

--- a/tests/e2e/backup-workflow.e2e.test.ts
+++ b/tests/e2e/backup-workflow.e2e.test.ts
@@ -14,19 +14,20 @@ import {
 	cleanupS3Prefix,
 	createDevice,
 	generateTestPrefix,
-	hasS3Credentials,
+	describeEachProvider,
 	initDevice,
 	teardownDevice,
 	type CreateDeviceOptions,
 	type E2EDevice,
+	type TestProvider,
 } from './helpers/e2e-harness';
 
-const describeIfS3 = hasS3Credentials() ? describe : describe.skip;
+const describeEach = describeEachProvider();
 
 /**
  * Create isolated E2E devices and clean up every generated S3 prefix.
  */
-describeIfS3('Backup workflow E2E', () => {
+describeEach('Backup workflow E2E [$name]', (provider: TestProvider) => {
 	let activeDevices: E2EDevice[] = [];
 	let cleanupTargets: Array<{ device: E2EDevice; prefixes: string[] }> = [];
 
@@ -34,10 +35,11 @@ describeIfS3('Backup workflow E2E', () => {
 	 * Create a fully initialized device with a unique S3 prefix for one scenario.
 	 */
 	async function createInitializedDevice(
-		overrides: Omit<CreateDeviceOptions, 'testPrefix'> = {},
+		overrides: Omit<CreateDeviceOptions, 'testPrefix' | 'provider'> = {},
 	): Promise<E2EDevice> {
 		const testPrefix = generateTestPrefix('backup-workflow');
 		const device = createDevice({
+			provider,
 			testPrefix,
 			...overrides,
 		});

--- a/tests/e2e/encryption-workflow.e2e.test.ts
+++ b/tests/e2e/encryption-workflow.e2e.test.ts
@@ -16,19 +16,24 @@ import { decrypt, encrypt } from '../../src/crypto/FileEncryptor';
 import { hashContent } from '../../src/crypto/Hasher';
 import { deriveKey } from '../../src/crypto/KeyDerivation';
 import { encodeMetadata } from '../../src/sync/SyncObjectMetadata';
-import { E2EDevice, cleanupS3Prefix, createDevice, generateTestPrefix, hasS3Credentials, initDevice, teardownDevice } from './helpers/e2e-harness';
+import { E2EDevice, TestProvider, cleanupS3Prefix, createDevice, generateTestPrefix, describeEachProvider, initDevice, teardownDevice } from './helpers/e2e-harness';
 
-const describeIfS3 = hasS3Credentials() ? describe : describe.skip;
+const describeEach = describeEachProvider();
 
 /**
  * Creates and initializes a device for a scenario-specific child prefix.
+ *
+ * `provider` selects which configured backend (R2, B2, …) the device targets;
+ * within a suite it is supplied by the per-provider `makeDevice` wrapper.
  */
 async function createInitializedDevice(options: {
+	provider: TestProvider;
 	deviceId: string;
 	testPrefix: string;
 	encryptionKey?: Uint8Array | null;
 }): Promise<E2EDevice> {
 	const device = createDevice({
+		provider: options.provider,
 		deviceId: options.deviceId,
 		testPrefix: options.testPrefix,
 		encryptionKey: options.encryptionKey ?? null,
@@ -63,18 +68,26 @@ async function createPlaintextFingerprint(content: string): Promise<string> {
 /**
  * Encryption workflows through the real sync pipeline and real S3.
  */
-describeIfS3('E2E encryption workflow', () => {
+describeEach('E2E encryption workflow [$name]', (provider: TestProvider) => {
 	let suitePrefix: string;
 	let suiteSalt: Uint8Array;
 	let suiteEncryptionKey: Uint8Array;
 	let suiteDevice: E2EDevice;
 	const devices: E2EDevice[] = [];
 
+	/**
+	 * Per-provider wrapper around {@link createInitializedDevice} that injects the
+	 * current suite's `provider`, so individual scenarios stay provider-agnostic.
+	 */
+	const makeDevice = (
+		options: { deviceId: string; testPrefix: string; encryptionKey?: Uint8Array | null },
+	): Promise<E2EDevice> => createInitializedDevice({ provider, ...options });
+
 	beforeAll(async () => {
 		suitePrefix = generateTestPrefix('encryption-workflow');
 		suiteSalt = randomFillSync(new Uint8Array(32));
 		suiteEncryptionKey = await deriveKey('correct horse battery staple', suiteSalt);
-		suiteDevice = await createInitializedDevice({
+		suiteDevice = await makeDevice({
 			deviceId: 'suite-encrypted-device',
 			testPrefix: suitePrefix,
 			encryptionKey: suiteEncryptionKey,
@@ -95,7 +108,7 @@ describeIfS3('E2E encryption workflow', () => {
 	/** Verifies that sync uploads ciphertext rather than plaintext bytes. */
 	it('uploads encrypted ciphertext to S3 instead of plaintext when encryption is enabled', async () => {
 		const scenarioPrefix = `${suitePrefix}/encrypted-upload`;
-		const device = await createInitializedDevice({
+		const device = await makeDevice({
 			deviceId: 'encrypted-upload-device',
 			testPrefix: scenarioPrefix,
 			encryptionKey: suiteEncryptionKey,
@@ -124,7 +137,7 @@ describeIfS3('E2E encryption workflow', () => {
 	/** Verifies that the codec can decrypt a downloaded encrypted payload. */
 	it('decrypts an encrypted S3 payload back to the original plaintext on download', async () => {
 		const scenarioPrefix = `${suitePrefix}/codec-decrypt`;
-		const device = await createInitializedDevice({
+		const device = await makeDevice({
 			deviceId: 'codec-decrypt-device',
 			testPrefix: scenarioPrefix,
 			encryptionKey: suiteEncryptionKey,
@@ -149,14 +162,14 @@ describeIfS3('E2E encryption workflow', () => {
 	/** Verifies a full encrypted round-trip between two devices sharing the same key. */
 	it('round-trips an encrypted file from device A to device B when both share the same key', async () => {
 		const scenarioPrefix = `${suitePrefix}/round-trip`;
-		const deviceA = await createInitializedDevice({
+		const deviceA = await makeDevice({
 			deviceId: 'device-a',
 			testPrefix: scenarioPrefix,
 			encryptionKey: suiteEncryptionKey,
 		});
 		devices.push(deviceA);
 
-		const deviceB = await createInitializedDevice({
+		const deviceB = await makeDevice({
 			deviceId: 'device-b',
 			testPrefix: scenarioPrefix,
 			encryptionKey: suiteEncryptionKey,
@@ -181,7 +194,7 @@ describeIfS3('E2E encryption workflow', () => {
 	/** Verifies that a device with the wrong key fails when it encounters encrypted content. */
 	it('fails gracefully when a second device syncs encrypted content with the wrong passphrase-derived key', async () => {
 		const scenarioPrefix = `${suitePrefix}/wrong-passphrase`;
-		const deviceA = await createInitializedDevice({
+		const deviceA = await makeDevice({
 			deviceId: 'wrong-pass-source',
 			testPrefix: scenarioPrefix,
 			encryptionKey: suiteEncryptionKey,
@@ -189,7 +202,7 @@ describeIfS3('E2E encryption workflow', () => {
 		devices.push(deviceA);
 
 		const wrongKey = await deriveKey('this is definitely the wrong passphrase', suiteSalt);
-		const deviceB = await createInitializedDevice({
+		const deviceB = await makeDevice({
 			deviceId: 'wrong-pass-target',
 			testPrefix: scenarioPrefix,
 			encryptionKey: wrongKey,
@@ -217,7 +230,7 @@ describeIfS3('E2E encryption workflow', () => {
 	/** Verifies that devices without an encryption key upload plaintext bytes. */
 	it('uploads plaintext bytes to S3 when no encryption key is configured', async () => {
 		const scenarioPrefix = `${suitePrefix}/plaintext-upload`;
-		const device = await createInitializedDevice({
+		const device = await makeDevice({
 			deviceId: 'plaintext-device',
 			testPrefix: scenarioPrefix,
 			encryptionKey: null,
@@ -242,7 +255,7 @@ describeIfS3('E2E encryption workflow', () => {
 	/** Verifies that an encrypted device still accepts plaintext-tagged remote payloads. */
 	it('downloads and reads plaintext-tagged remote objects even when the syncing device has encryption enabled', async () => {
 		const scenarioPrefix = `${suitePrefix}/mixed-format`;
-		const device = await createInitializedDevice({
+		const device = await makeDevice({
 			deviceId: 'mixed-format-device',
 			testPrefix: scenarioPrefix,
 			encryptionKey: suiteEncryptionKey,
@@ -272,7 +285,7 @@ describeIfS3('E2E encryption workflow', () => {
 	/** Verifies that a manually encrypted remote object is readable through the sync pipeline. */
 	it('downloads a manually encrypted remote object when metadata marks it as xsalsa20poly1305-v1', async () => {
 		const scenarioPrefix = `${suitePrefix}/manual-encrypted-object`;
-		const device = await createInitializedDevice({
+		const device = await makeDevice({
 			deviceId: 'manual-encrypted-device',
 			testPrefix: scenarioPrefix,
 			encryptionKey: suiteEncryptionKey,

--- a/tests/e2e/helpers/e2e-harness.ts
+++ b/tests/e2e/helpers/e2e-harness.ts
@@ -6,8 +6,6 @@
  * and fake-indexeddb (SyncJournal) instead of the Obsidian runtime.
  */
 
-import { S3Client } from '@aws-sdk/client-s3';
-import { NodeHttpHandler } from '@smithy/node-http-handler';
 import { App } from 'obsidian';
 
 import { S3SyncBackupSettings } from '../../../src/types';
@@ -21,13 +19,17 @@ import { SnapshotCreator } from '../../../src/backup/SnapshotCreator';
 import { RetentionManager } from '../../../src/backup/RetentionManager';
 import { E2EVault, E2EApp } from './mock-vault';
 import {
+	TestProvider,
 	hasS3Credentials,
-	getS3Config,
+	getConfiguredProviders,
+	describeEachProvider,
+	createTestS3Client,
 	getTestPrefix,
 	createTestSettings,
 } from '../../helpers/s3-test-utils';
 
-export { hasS3Credentials };
+export { hasS3Credentials, getConfiguredProviders, describeEachProvider };
+export type { TestProvider };
 
 /** All modules wired up for a single simulated device. */
 export interface E2EDevice {
@@ -47,6 +49,8 @@ export interface E2EDevice {
 
 /** Options for creating an E2E device. */
 export interface CreateDeviceOptions {
+	/** Provider matrix entry whose real bucket/credentials this device targets. */
+	provider: TestProvider;
 	deviceId?: string;
 	encryptionKey?: Uint8Array | null;
 	settingsOverrides?: Partial<S3SyncBackupSettings>;
@@ -57,26 +61,18 @@ export interface CreateDeviceOptions {
 /**
  * Creates a fully wired E2E device — real plugin modules backed by in-memory
  * vault, fake-indexeddb journal, and real S3.
+ *
+ * The injected `S3Client` is built via {@link createTestS3Client}, which routes
+ * through the plugin's production config builder (so the checksum fix and all
+ * provider-specific knobs are exercised) with only the HTTP handler swapped for
+ * a Node-compatible one.
  */
 export function createDevice(options: CreateDeviceOptions): E2EDevice {
 	const deviceId = options.deviceId ?? `e2e-device-${Math.random().toString(36).substring(7)}`;
-	const config = getS3Config();
 
-	const nodeClient = new S3Client({
-		endpoint: config.endpoint,
-		region: config.region,
-		credentials: {
-			accessKeyId: config.accessKeyId,
-			secretAccessKey: config.secretAccessKey,
-		},
-		forcePathStyle: true,
-		requestHandler: new NodeHttpHandler({
-			connectionTimeout: 5000,
-			socketTimeout: 30000,
-		}),
-	});
+	const nodeClient = createTestS3Client(options.provider);
 
-	const settings = createTestSettings({
+	const settings = createTestSettings(options.provider, {
 		syncPrefix: options.testPrefix,
 		backupPrefix: `${options.testPrefix}-backups`,
 		debugLogging: true,

--- a/tests/e2e/multi-device.e2e.test.ts
+++ b/tests/e2e/multi-device.e2e.test.ts
@@ -14,13 +14,14 @@ import {
 	cleanupS3Prefix,
 	createDevice,
 	type E2EDevice,
+	type TestProvider,
 	generateTestPrefix,
-	hasS3Credentials,
+	describeEachProvider,
 	initDevice,
 	teardownDevice,
 } from './helpers/e2e-harness';
 
-const describeIfS3 = hasS3Credentials() ? describe : describe.skip;
+const describeEach = describeEachProvider();
 
 function getFileOrThrow(device: E2EDevice, path: string): TFile {
 	const file = device.vault.getAbstractFileByPath(path);
@@ -59,15 +60,15 @@ function expectSuccessfulSync(result: SyncResult): void {
  * Covers real multi-device reconciliation using two independent devices that
  * share one S3 prefix but maintain separate local vaults and journals.
  */
-describeIfS3('E2E multi-device sync', () => {
+describeEach('E2E multi-device sync [$name]', (provider: TestProvider) => {
 	let testPrefix: string;
 	let deviceA: E2EDevice;
 	let deviceB: E2EDevice;
 
 	beforeEach(async () => {
 		testPrefix = generateTestPrefix('multi-device');
-		deviceA = createDevice({ testPrefix, deviceId: 'device-a' });
-		deviceB = createDevice({ testPrefix, deviceId: 'device-b' });
+		deviceA = createDevice({ provider, testPrefix, deviceId: 'device-a' });
+		deviceB = createDevice({ provider, testPrefix, deviceId: 'device-b' });
 
 		await initDevice(deviceA);
 		await initDevice(deviceB);

--- a/tests/e2e/sync-workflow.e2e.test.ts
+++ b/tests/e2e/sync-workflow.e2e.test.ts
@@ -14,13 +14,14 @@ import {
 	cleanupS3Prefix,
 	createDevice,
 	generateTestPrefix,
-	hasS3Credentials,
+	describeEachProvider,
 	initDevice,
 	teardownDevice,
 	type E2EDevice,
+	type TestProvider,
 } from './helpers/e2e-harness';
 
-const describeIfS3 = hasS3Credentials() ? describe : describe.skip;
+const describeEach = describeEachProvider();
 
 /**
  * Builds the metadata required for a direct-to-S3 upload that the sync planner
@@ -56,13 +57,13 @@ function getRequiredVaultFile(device: E2EDevice, path: string): TFile {
  * Covers the single-device sync pipeline against real S3 for create, update,
  * delete, exclusion, and binary-file workflows.
  */
-describeIfS3('Sync workflow E2E tests', () => {
+describeEach('Sync workflow E2E tests [$name]', (provider: TestProvider) => {
 	let device: E2EDevice;
 	let testPrefix: string;
 
 	beforeAll(async () => {
 		testPrefix = generateTestPrefix('sync');
-		device = createDevice({ testPrefix });
+		device = createDevice({ provider, testPrefix });
 		await initDevice(device);
 	});
 

--- a/tests/helpers/s3-test-utils.ts
+++ b/tests/helpers/s3-test-utils.ts
@@ -1,32 +1,100 @@
 /**
- * Test utilities for S3 integration tests
+ * Test utilities for S3 integration & E2E tests — multi-provider aware.
  *
- * Provides S3 client configuration that works in Node.js test environment
- * (bypassing Obsidian-specific HTTP handler)
+ * Integration/E2E tests exercise REAL S3 operations. To catch provider-specific
+ * regressions (e.g. Backblaze B2's rejection of modern checksum headers — issue
+ * #78), the suite runs against every provider whose credentials are configured,
+ * not just one. Each provider's credentials live under a distinct env-var prefix
+ * (`CF_`, `BB_`, …) so several providers can be tested in a single run.
  *
- * Note: Environment variables are loaded via Node.js --env-file flag in npm script
+ * Env-var scheme (per provider `<PREFIX>`):
+ *   <PREFIX>URL                — S3-compatible endpoint URL
+ *   <PREFIX>BUCKET_NAME        — bucket to run tests against
+ *   <PREFIX>ACCESS_KEY         — access key id
+ *   <PREFIX>SECRET_ACCESS_KEY  — secret access key
+ *   <PREFIX>REGION             — region (defaults to "auto")
+ *
+ * Example: `CF_URL`, `CF_BUCKET_NAME`, … for Cloudflare R2; `BB_URL`, … for B2.
+ *
+ * Note: environment variables are loaded via Node.js `--env-file=.env` in the
+ * `test:integration` / `test:e2e` npm scripts (no dotenv dependency).
  */
 
-import { S3Client } from '@aws-sdk/client-s3';
+import { S3Client, S3ClientConfig } from '@aws-sdk/client-s3';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
-import { S3SyncBackupSettings } from '../../src/types';
+import { S3ProviderType, S3SyncBackupSettings } from '../../src/types';
+import { buildS3ClientConfig } from '../../src/storage/S3Config';
 
 /**
- * Check if S3 credentials are configured
+ * A provider entry in the test matrix.
+ *
+ * @property id        Short slug used in `describe` titles and object logs (e.g. `'cf'`).
+ * @property name      Human-readable provider name shown in test output (e.g. `'Cloudflare R2'`).
+ * @property envPrefix Env-var prefix carrying this provider's credentials (e.g. `'CF_'`).
+ * @property provider  Plugin `S3ProviderType` this maps to, so tests build the
+ *                     same client config the plugin would in production.
  */
-export function hasS3Credentials(): boolean {
+export interface TestProvider {
+    id: string;
+    name: string;
+    envPrefix: string;
+    provider: S3ProviderType;
+}
+
+/**
+ * The provider test matrix. A provider is included in a run only when its
+ * credentials are present (see {@link getConfiguredProviders}), so this list can
+ * grow ahead of the credentials being available in any given environment.
+ *
+ * To add a provider: append an entry here and document its env vars in
+ * `.env.sample` — no other test code changes are required.
+ */
+export const TEST_PROVIDERS: TestProvider[] = [
+    { id: 'cf', name: 'Cloudflare R2', envPrefix: 'CF_', provider: 'r2' },
+    { id: 'bb', name: 'Backblaze B2', envPrefix: 'BB_', provider: 'b2' },
+    // Future providers (add credentials + uncomment):
+    // { id: 'aws', name: 'AWS S3', envPrefix: 'AWS_', provider: 'aws' },
+    // { id: 'rustfs', name: 'RustFS', envPrefix: 'RUSTFS_', provider: 'rustfs' },
+];
+
+/**
+ * A placeholder provider used only to keep `describe.skip.each` non-empty when no
+ * real providers are configured — Jest errors on a test file containing zero tests.
+ */
+const PLACEHOLDER_PROVIDER: TestProvider = {
+    id: 'none',
+    name: 'no providers configured',
+    envPrefix: '',
+    provider: 'custom',
+};
+
+/** Read a prefixed env var for a provider, returning `''` when unset. */
+function readEnv(provider: TestProvider, key: string): string {
+    return process.env[`${provider.envPrefix}${key}`] || '';
+}
+
+/**
+ * Check whether the given provider has the minimum credentials configured.
+ *
+ * @param provider - Provider matrix entry.
+ * @returns `true` when URL, bucket, access key, and secret are all present.
+ */
+export function hasS3Credentials(provider: TestProvider): boolean {
     return !!(
-        process.env.S3_URL &&
-        process.env.S3_BUCKET_NAME &&
-        process.env.S3_ACCESS_KEY &&
-        process.env.S3_SECRET_ACCESS_KEY
+        readEnv(provider, 'URL') &&
+        readEnv(provider, 'BUCKET_NAME') &&
+        readEnv(provider, 'ACCESS_KEY') &&
+        readEnv(provider, 'SECRET_ACCESS_KEY')
     );
 }
 
 /**
- * Get S3 configuration from environment variables
+ * Get raw S3 configuration for a provider from its prefixed env vars.
+ *
+ * @param provider - Provider matrix entry.
+ * @returns Connection fields; `region` defaults to `'auto'` when unset.
  */
-export function getS3Config(): {
+export function getS3Config(provider: TestProvider): {
     endpoint: string;
     bucket: string;
     accessKeyId: string;
@@ -34,72 +102,99 @@ export function getS3Config(): {
     region: string;
 } {
     return {
-        endpoint: process.env.S3_URL || '',
-        bucket: process.env.S3_BUCKET_NAME || '',
-        accessKeyId: process.env.S3_ACCESS_KEY || '',
-        secretAccessKey: process.env.S3_SECRET_ACCESS_KEY || '',
-        region: process.env.S3_REGION || 'auto',
+        endpoint: readEnv(provider, 'URL'),
+        bucket: readEnv(provider, 'BUCKET_NAME'),
+        accessKeyId: readEnv(provider, 'ACCESS_KEY'),
+        secretAccessKey: readEnv(provider, 'SECRET_ACCESS_KEY'),
+        region: readEnv(provider, 'REGION') || 'auto',
     };
 }
 
 /**
- * Creates a test S3 client that works in Node.js environment
- * (Uses NodeHttpHandler instead of Obsidian's requestUrl)
+ * Return every provider in {@link TEST_PROVIDERS} that has credentials configured.
+ * This is the driver for `describe.each` so only reachable providers are tested.
+ *
+ * @returns Filtered list of configured providers (possibly empty).
  */
-export function createTestS3Client(): S3Client {
-    const config = getS3Config();
+export function getConfiguredProviders(): TestProvider[] {
+    return TEST_PROVIDERS.filter(hasS3Credentials);
+}
 
-    return new S3Client({
-        endpoint: config.endpoint,
-        region: config.region,
-        credentials: {
-            accessKeyId: config.accessKeyId,
-            secretAccessKey: config.secretAccessKey,
-        },
-        forcePathStyle: true,
-        // Use Node.js-compatible HTTP handler for tests
-        requestHandler: new NodeHttpHandler({
-            connectionTimeout: 5000,
-            socketTimeout: 30000,
-        }),
-    });
+/** Signature of a `describe.each`-style runner bound to the provider matrix. */
+type ProviderDescribe = (name: string, fn: (provider: TestProvider) => void) => void;
+
+/**
+ * Return a `describe.each` runner over all configured providers.
+ *
+ * Usage:
+ * ```ts
+ * describeEachProvider()('S3 ops [$name]', (provider) => { ... });
+ * ```
+ * The `$name` token interpolates the provider's display name into the suite title.
+ * When no providers are configured, returns a **skipped** runner over a single
+ * placeholder so the file still registers (skipped) tests instead of erroring.
+ *
+ * @returns A function accepting a title template and a per-provider suite body.
+ */
+export function describeEachProvider(): ProviderDescribe {
+    const providers = getConfiguredProviders();
+    if (providers.length === 0) {
+        console.warn(
+            '⚠️ No S3 providers configured (set CF_*/BB_* env vars in .env); skipping provider tests.',
+        );
+        return describe.skip.each([PLACEHOLDER_PROVIDER]);
+    }
+    return describe.each(providers);
 }
 
 /**
- * Creates test settings from environment variables
+ * Create a test S3 client for a provider that works in the Node.js test runtime.
+ *
+ * Crucially, this routes through the plugin's production {@link buildS3ClientConfig}
+ * so tests exercise the *exact* client configuration the plugin uses — including
+ * the checksum settings that fix issue #78 — and only swaps the Obsidian
+ * `requestHandler` for a Node-compatible `NodeHttpHandler` (Obsidian's
+ * `requestUrl` is unavailable outside the app).
+ *
+ * @param provider - Provider matrix entry.
+ * @returns A configured `S3Client` talking to the provider's real endpoint.
  */
-export function createTestSettings(overrides: Partial<S3SyncBackupSettings> = {}): S3SyncBackupSettings {
-    const config = getS3Config();
+export function createTestS3Client(provider: TestProvider): S3Client {
+    const config: S3ClientConfig = buildS3ClientConfig(createTestSettings(provider));
+    config.requestHandler = new NodeHttpHandler({
+        connectionTimeout: 5000,
+        socketTimeout: 30000,
+    });
+    return new S3Client(config);
+}
 
-    // Determine provider from endpoint hostname (parsed to avoid substring spoofing,
-    // e.g. an attacker-controlled URL like "evil.amazonaws.com.attacker.com" would
-    // incorrectly match a plain .includes('amazonaws.com') check).
-    let provider: 'aws' | 'r2' | 'rustfs' | 'custom';
-    let endpointHostname = '';
-    try {
-        endpointHostname = new URL(config.endpoint).hostname;
-    } catch {
-        // endpoint is empty or not a valid URL — leave hostname as empty string
-    }
-    if (endpointHostname === 'r2.cloudflarestorage.com' || endpointHostname.endsWith('.r2.cloudflarestorage.com')) {
-        provider = 'r2';
-    } else if (endpointHostname.endsWith('.amazonaws.com') || !config.endpoint) {
-        provider = 'aws';
-    } else if (endpointHostname === 'localhost' || endpointHostname.includes('rustfs')) {
-        provider = 'rustfs';
-    } else {
-        provider = 'custom';
-    }
+/**
+ * Build a full plugin settings object for a provider from its env vars.
+ *
+ * The plugin `provider` type comes straight from the matrix entry (no hostname
+ * inference), so it always matches the credentials being used.
+ *
+ * @param provider  - Provider matrix entry.
+ * @param overrides - Partial settings to merge over the env-derived defaults.
+ * @returns A complete {@link S3SyncBackupSettings} for use with `S3Provider`.
+ */
+export function createTestSettings(
+    provider: TestProvider,
+    overrides: Partial<S3SyncBackupSettings> = {},
+): S3SyncBackupSettings {
+    const config = getS3Config(provider);
 
     return {
-        provider,
+        provider: provider.provider,
         endpoint: config.endpoint,
         region: config.region,
         bucket: config.bucket,
         accessKeyId: config.accessKeyId,
         secretAccessKey: config.secretAccessKey,
-        forcePathStyle: provider !== 'aws',
+        forcePathStyle: provider.provider !== 'aws',
         encryptionEnabled: false,
+        rememberPassphrase: false,
+        savedPassphrase: '',
         syncEnabled: true,
         syncPrefix: 'vault',
         autoSyncEnabled: false,
@@ -119,7 +214,10 @@ export function createTestSettings(overrides: Partial<S3SyncBackupSettings> = {}
 }
 
 /**
- * Generate unique test prefix to avoid conflicts
+ * Generate a unique S3 prefix to isolate a test run from concurrent/previous runs.
+ *
+ * @param testName - Short label included in the prefix for debuggability.
+ * @returns A prefix of the form `__test__/{name}-{timestamp}-{random}`.
  */
 export function getTestPrefix(testName: string): string {
     const timestamp = Date.now();

--- a/tests/storage/ProviderCompatibility.integration.test.ts
+++ b/tests/storage/ProviderCompatibility.integration.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Provider-compatibility matrix — REAL S3 operations against every configured provider.
+ *
+ * This is the definitive cross-provider suite: it exercises the plugin's *actual*
+ * {@link S3Provider} methods (not raw SDK commands) against each provider whose
+ * credentials are configured (Cloudflare R2, Backblaze B2, and any future
+ * providers added to `TEST_PROVIDERS`). The `S3Provider` is constructed with a
+ * Node-compatible client built via {@link createTestS3Client}, which routes
+ * through the plugin's production `buildS3ClientConfig` — so these tests validate
+ * the exact wire behaviour end users get, including the checksum fix for issue #78.
+ *
+ * Issue #78 ("not compatible with Backblaze B2") had two distinct causes, both
+ * exercised here:
+ *   1. The **conditional-write** tests are the true B2 regression — B2's S3 API
+ *      does not implement `If-Match`/`If-None-Match` on `PutObject` and returns
+ *      `NotImplemented`. They pass only because `S3Provider.uploadFile` emulates
+ *      the guard with a `HeadObject` pre-check for providers that lack it.
+ *   2. The upload tests also cover the AWS-SDK checksum-portability path (some
+ *      S3-compatible providers reject the default `x-amz-checksum-*` headers).
+ *
+ * Each provider run isolates its objects under a unique `__test__/` prefix and
+ * cleans them up in `afterAll`. Requires credentials in `.env` (see `.env.sample`);
+ * providers without credentials are skipped automatically.
+ */
+
+import { S3Provider } from '../../src/storage/S3Provider';
+import {
+    TestProvider,
+    createTestS3Client,
+    createTestSettings,
+    describeEachProvider,
+    getS3Config,
+    getTestPrefix,
+} from '../helpers/s3-test-utils';
+
+describeEachProvider()('Provider compatibility [$name]', (provider: TestProvider) => {
+    let s3: S3Provider;
+    let bucket: string;
+    let testPrefix: string;
+    const createdKeys: string[] = [];
+
+    beforeAll(() => {
+        // Inject the faithful Node client so the real S3Provider talks to the
+        // provider's endpoint with the plugin's production client config.
+        s3 = new S3Provider(createTestSettings(provider), createTestS3Client(provider));
+        bucket = getS3Config(provider).bucket;
+        testPrefix = getTestPrefix(`compat-${provider.id}`);
+    });
+
+    afterAll(async () => {
+        if (createdKeys.length > 0) {
+            try {
+                await s3.deleteFiles(createdKeys);
+            } catch {
+                console.warn(`Failed to clean up some test files for ${provider.name}`);
+            }
+        }
+        s3.destroy();
+    });
+
+    /** Track a key for afterAll cleanup and return it for inline use. */
+    function trackKey(key: string): string {
+        createdKeys.push(key);
+        return key;
+    }
+
+    /**
+     * Connectivity: the same operation the settings "Test connection" button runs.
+     * Uses bodyless HeadBucket, so it never carried the checksum header that
+     * issue #78 tripped over — it succeeded even on B2 before the fix.
+     */
+    describe('Connection', () => {
+        it('connects to the configured bucket', async () => {
+            const message = await s3.testConnection();
+            expect(message).toContain(bucket);
+        });
+    });
+
+    /**
+     * Upload/download round-trips. These cover the checksum-portability path:
+     * PutObject carries a body, so the SDK's default `x-amz-checksum-*` headers
+     * are attached unless suppressed — some S3-compatible providers reject them.
+     */
+    describe('Upload and download', () => {
+        it('round-trips UTF-8 text', async () => {
+            const key = trackKey(`${testPrefix}/text.md`);
+            const content = 'Hello from the provider matrix — issue #78 regression check.';
+
+            await s3.uploadFile(key, content, 'text/markdown');
+            const result = await s3.downloadFileAsTextWithEtag(key);
+
+            expect(result?.text).toBe(content);
+        });
+
+        it('round-trips binary content', async () => {
+            const key = trackKey(`${testPrefix}/binary.bin`);
+            const content = new Uint8Array([0, 1, 2, 255, 128, 64, 32, 16, 8, 4]);
+
+            await s3.uploadFile(key, content, 'application/octet-stream');
+            const downloaded = await s3.downloadFile(key);
+
+            expect(downloaded).toEqual(content);
+        });
+
+        it('round-trips a large file (256 KB)', async () => {
+            const key = trackKey(`${testPrefix}/large.bin`);
+            const content = new Uint8Array(256 * 1024);
+            for (let i = 0; i < content.length; i++) {
+                content[i] = i % 256;
+            }
+
+            await s3.uploadFile(key, content, 'application/octet-stream');
+            const downloaded = await s3.downloadFile(key);
+
+            expect(downloaded.length).toBe(content.length);
+            expect(downloaded).toEqual(content);
+        });
+
+        it('round-trips Unicode content', async () => {
+            const key = trackKey(`${testPrefix}/unicode.md`);
+            const content = '# 日本語テスト\n\nこんにちは世界 🌍';
+
+            await s3.uploadFile(key, content, 'text/markdown');
+            const result = await s3.downloadFileAsTextWithEtag(key);
+
+            expect(result?.text).toBe(content);
+        });
+    });
+
+    /**
+     * Custom object metadata round-trip. The sync engine stores content identity
+     * and timing in S3 custom metadata (`obsidian-mtime`, `obsidian-fingerprint`,
+     * `obsidian-device-id`); if a provider drops or mangles these, sync breaks.
+     */
+    describe('Object metadata', () => {
+        it('round-trips plugin custom metadata', async () => {
+            const key = trackKey(`${testPrefix}/with-metadata.md`);
+
+            await s3.uploadFile(key, 'body with metadata', {
+                contentType: 'text/markdown',
+                metadata: {
+                    'obsidian-mtime': '1717171717000',
+                    'obsidian-fingerprint': 'deadbeefcafe',
+                    'obsidian-device-id': 'matrix-device',
+                },
+            });
+
+            const head = await s3.headObject(key);
+
+            expect(head).not.toBeNull();
+            expect(head?.clientMtime).toBe(1717171717000);
+            expect(head?.fingerprint).toBe('deadbeefcafe');
+            expect(head?.deviceId).toBe('matrix-device');
+        });
+    });
+
+    /**
+     * Listing: prefix scoping and empty results. Sync's discovery phase depends
+     * on ListObjectsV2 returning every key under the sync prefix.
+     */
+    describe('List objects', () => {
+        it('lists objects under a prefix', async () => {
+            const listPrefix = `${testPrefix}/list`;
+            await s3.uploadFile(trackKey(`${listPrefix}/a.txt`), 'a');
+            await s3.uploadFile(trackKey(`${listPrefix}/b.txt`), 'b');
+            await s3.uploadFile(trackKey(`${listPrefix}/nested/c.txt`), 'c');
+
+            const objects = await s3.listObjects(listPrefix);
+
+            expect(objects.length).toBe(3);
+            expect(objects.some(o => o.key.endsWith('a.txt'))).toBe(true);
+            expect(objects.some(o => o.key.endsWith('b.txt'))).toBe(true);
+            expect(objects.some(o => o.key.endsWith('nested/c.txt'))).toBe(true);
+        });
+
+        it('returns empty for a non-existent prefix', async () => {
+            const objects = await s3.listObjects(`${testPrefix}/does-not-exist`);
+            expect(objects).toEqual([]);
+        });
+    });
+
+    /**
+     * Conditional writes back the sync engine's optimistic-concurrency guards
+     * (`uploadFile` with `ifNoneMatch: '*'` for create-only, `ifMatch` for
+     * update-only). **This is the true issue #78 regression for Backblaze B2**:
+     * B2 rejects native conditional `PutObject` with `NotImplemented`, so these
+     * pass only because `S3Provider.uploadFile` emulates the guard via a
+     * `HeadObject` pre-check for providers that lack native support. Providers
+     * with native support (R2/AWS) exercise the real headers.
+     */
+    describe('Conditional writes', () => {
+        it('create-only (If-None-Match: *) rejects an already-existing key', async () => {
+            const key = trackKey(`${testPrefix}/cond-create.md`);
+
+            await s3.uploadFile(key, 'first write', { ifNoneMatch: '*' });
+
+            await expect(
+                s3.uploadFile(key, 'second write', { ifNoneMatch: '*' }),
+            ).rejects.toThrow();
+        });
+
+        it('update-only (If-Match) succeeds on the current ETag and fails on a stale one', async () => {
+            const key = trackKey(`${testPrefix}/cond-update.md`);
+
+            const firstEtag = await s3.uploadFile(key, 'v1');
+            const secondEtag = await s3.uploadFile(key, 'v2', { ifMatch: firstEtag });
+
+            expect(secondEtag).toBeTruthy();
+            expect(secondEtag).not.toBe(firstEtag);
+
+            // The first ETag is now stale — an If-Match against it must be rejected.
+            await expect(
+                s3.uploadFile(key, 'v3', { ifMatch: firstEtag }),
+            ).rejects.toThrow();
+        });
+    });
+
+    /**
+     * Deletion. Single-object delete has no required checksum; batch delete
+     * (DeleteObjects) is the one operation still checksummed even after the
+     * issue #78 fix, so it is the "decide by test" case for B2 compatibility.
+     */
+    describe('Delete operations', () => {
+        it('deletes a single object', async () => {
+            const key = `${testPrefix}/delete-single.txt`;
+            await s3.uploadFile(key, 'to delete');
+
+            const deleted = await s3.deleteFiles([key]);
+            expect(deleted).toBe(1);
+
+            const objects = await s3.listObjects(key);
+            expect(objects).toEqual([]);
+        });
+
+        it('batch-deletes multiple objects', async () => {
+            const batchPrefix = `${testPrefix}/batch-delete`;
+            const keys = [
+                `${batchPrefix}/file1.txt`,
+                `${batchPrefix}/file2.txt`,
+                `${batchPrefix}/file3.txt`,
+            ];
+            for (const key of keys) {
+                await s3.uploadFile(key, 'content');
+            }
+
+            const deleted = await s3.deleteFiles(keys);
+            expect(deleted).toBe(keys.length);
+
+            const objects = await s3.listObjects(batchPrefix);
+            expect(objects).toEqual([]);
+        });
+    });
+});

--- a/tests/storage/S3Config.test.ts
+++ b/tests/storage/S3Config.test.ts
@@ -12,6 +12,7 @@ import {
     buildS3ClientConfig,
     validateConnectionSettings,
     getProviderDisplayName,
+    providerSupportsConditionalWrites,
 } from '../../src/storage/S3Config';
 import { S3SyncBackupSettings, S3_PROVIDER_NAMES } from '../../src/types';
 
@@ -81,6 +82,28 @@ describe('S3Config', () => {
         });
 
         /**
+         * Backblaze B2 exposes a regional S3-compatible endpoint
+         */
+        it('should return endpoint for B2 provider', () => {
+            const settings = createTestSettings({
+                provider: 'b2',
+                endpoint: 'https://s3.us-west-004.backblazeb2.com',
+            });
+            expect(getEndpointForProvider(settings)).toBe('https://s3.us-west-004.backblazeb2.com');
+        });
+
+        /**
+         * B2 without endpoint should throw error
+         */
+        it('should throw error for B2 without endpoint', () => {
+            const settings = createTestSettings({
+                provider: 'b2',
+                endpoint: '',
+            });
+            expect(() => getEndpointForProvider(settings)).toThrow('Backblaze B2 requires an endpoint URL');
+        });
+
+        /**
          * RustFS requires a custom endpoint URL (typically localhost:9000)
          */
         it('should return endpoint for RustFS provider', () => {
@@ -139,6 +162,14 @@ describe('S3Config', () => {
          */
         it('should return true for R2', () => {
             const settings = createTestSettings({ provider: 'r2' });
+            expect(shouldForcePathStyle(settings)).toBe(true);
+        });
+
+        /**
+         * B2 works better with path-style (reliable across bucket names)
+         */
+        it('should return true for B2', () => {
+            const settings = createTestSettings({ provider: 'b2' });
             expect(shouldForcePathStyle(settings)).toBe(true);
         });
 
@@ -234,6 +265,22 @@ describe('S3Config', () => {
 
             expect(config.region).toBe('auto');
         });
+
+        /**
+         * Portability guard: the AWS SDK defaults `requestChecksumCalculation` to
+         * `'WHEN_SUPPORTED'` since v3.729.0, attaching `x-amz-checksum-*` headers
+         * that AWS documents some third-party S3-compatible services reject.
+         * `buildS3ClientConfig` must pin both checksum knobs to `'WHEN_REQUIRED'`
+         * so uploads stay portable. This applies to every provider, so AWS is a
+         * sufficient sample. (The confirmed Backblaze B2 blocker in issue #78 was
+         * conditional writes, covered separately in S3Provider.)
+         */
+        it('should disable default request/response checksums for portability', () => {
+            const config = buildS3ClientConfig(createTestSettings({ provider: 'aws' }));
+
+            expect(config.requestChecksumCalculation).toBe('WHEN_REQUIRED');
+            expect(config.responseChecksumValidation).toBe('WHEN_REQUIRED');
+        });
     });
 
     describe('validateConnectionSettings', () => {
@@ -283,6 +330,18 @@ describe('S3Config', () => {
             });
             const errors = validateConnectionSettings(settings);
             expect(errors).toContain('Cloudflare R2 requires an endpoint URL');
+        });
+
+        /**
+         * B2 without endpoint should be caught
+         */
+        it('should return error for B2 without endpoint', () => {
+            const settings = createTestSettings({
+                provider: 'b2',
+                endpoint: '',
+            });
+            const errors = validateConnectionSettings(settings);
+            expect(errors).toContain('Backblaze B2 requires an endpoint URL');
         });
 
         /**
@@ -385,6 +444,10 @@ describe('S3Config', () => {
             expect(getProviderDisplayName('r2')).toBe('Cloudflare R2');
         });
 
+        it('should return correct display name for B2', () => {
+            expect(getProviderDisplayName('b2')).toBe('Backblaze B2');
+        });
+
         it('should return correct display name for other S3-compatible', () => {
             expect(getProviderDisplayName('custom')).toBe('Other S3-compatible');
         });
@@ -399,6 +462,24 @@ describe('S3Config', () => {
     });
 
     /**
+     * B2 lacks conditional PutObject; every other provider supports it. The sync
+     * engine relies on this flag to decide between native conditional headers and
+     * the HeadObject emulation in S3Provider.uploadFile.
+     */
+    describe('providerSupportsConditionalWrites', () => {
+        it('returns false for Backblaze B2', () => {
+            expect(providerSupportsConditionalWrites('b2')).toBe(false);
+        });
+
+        it('returns true for AWS, R2, RustFS, and custom', () => {
+            expect(providerSupportsConditionalWrites('aws')).toBe(true);
+            expect(providerSupportsConditionalWrites('r2')).toBe(true);
+            expect(providerSupportsConditionalWrites('rustfs')).toBe(true);
+            expect(providerSupportsConditionalWrites('custom')).toBe(true);
+        });
+    });
+
+    /**
      * The settings dropdown is rendered by iterating `Object.entries(S3_PROVIDER_NAMES)`
      * (see `src/settings.ts`). For non-integer string keys, JavaScript guarantees
      * iteration in insertion order, so the order in which entries are declared
@@ -407,7 +488,7 @@ describe('S3Config', () => {
      */
     describe('S3_PROVIDER_NAMES dropdown order', () => {
         it('exposes providers in the documented dropdown order', () => {
-            expect(Object.keys(S3_PROVIDER_NAMES)).toEqual(['aws', 'r2', 'rustfs', 'custom']);
+            expect(Object.keys(S3_PROVIDER_NAMES)).toEqual(['aws', 'r2', 'b2', 'rustfs', 'custom']);
         });
     });
 });

--- a/tests/storage/S3Provider.integration.test.ts
+++ b/tests/storage/S3Provider.integration.test.ts
@@ -1,12 +1,16 @@
 /**
- * Integration tests for S3 operations
+ * Integration tests for raw S3 operations — per provider.
  *
- * These tests perform REAL S3 operations against a configured S3-compatible bucket.
- * Uses direct S3Client (not S3Provider) to avoid Obsidian-specific dependencies.
+ * These tests perform REAL S3 operations against every configured S3-compatible
+ * bucket (Cloudflare R2, Backblaze B2, …). They use a direct `S3Client` (built
+ * via the plugin's production config through `createTestS3Client`) rather than
+ * `S3Provider`, to validate wire-level SDK behaviour independently of the
+ * higher-level provider wrapper. For plugin-method coverage see
+ * `ProviderCompatibility.integration.test.ts`.
  *
- * Test files are created under __test__/ prefix and cleaned up after each test.
- *
- * Environment variables required (see .env.sample)
+ * Test files are created under a unique `__test__/` prefix and cleaned up after
+ * the run. Providers without credentials are skipped automatically
+ * (see `.env.sample`).
  */
 
 import {
@@ -19,57 +23,22 @@ import {
     HeadBucketCommand,
 } from '@aws-sdk/client-s3';
 import {
+    TestProvider,
     createTestS3Client,
-    hasS3Credentials,
     getS3Config,
     getTestPrefix,
+    describeEachProvider,
 } from '../helpers/s3-test-utils';
 
-/**
- * Helper to convert stream to Uint8Array
- */
-async function streamToBytes(stream: ReadableStream<Uint8Array> | NodeJS.ReadableStream): Promise<Uint8Array> {
-    const chunks: Uint8Array[] = [];
-
-    // Handle both Web ReadableStream and Node.js ReadableStream
-    if ('getReader' in stream) {
-        // Web ReadableStream
-        const reader = stream.getReader();
-        while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            if (value) chunks.push(value);
-        }
-    } else {
-        // Node.js ReadableStream
-        for await (const chunk of stream as AsyncIterable<Buffer>) {
-            chunks.push(new Uint8Array(chunk));
-        }
-    }
-
-    const totalLength = chunks.reduce((acc, chunk) => acc + chunk.length, 0);
-    const result = new Uint8Array(totalLength);
-    let offset = 0;
-    for (const chunk of chunks) {
-        result.set(chunk, offset);
-        offset += chunk.length;
-    }
-    return result;
-}
-
-describe('S3 Integration Tests', () => {
+describeEachProvider()('S3 Integration Tests [$name]', (provider: TestProvider) => {
     let client: S3Client;
     let bucket: string;
     let testPrefix: string;
     const createdKeys: string[] = [];
 
     beforeAll(() => {
-        if (!hasS3Credentials()) {
-            console.warn('⚠️ S3 credentials not configured, skipping integration tests');
-            return;
-        }
-        client = createTestS3Client();
-        bucket = getS3Config().bucket;
+        client = createTestS3Client(provider);
+        bucket = getS3Config(provider).bucket;
         testPrefix = getTestPrefix('s3');
     });
 
@@ -85,7 +54,7 @@ describe('S3 Integration Tests', () => {
                     },
                 }));
             } catch {
-                console.warn('Failed to clean up some test files');
+                console.warn(`Failed to clean up some test files for ${provider.name}`);
             }
             client.destroy();
         }
@@ -98,8 +67,6 @@ describe('S3 Integration Tests', () => {
 
     describe('Connection', () => {
         it('should successfully connect to configured bucket', async () => {
-            if (!hasS3Credentials()) return;
-
             const response = await client.send(new HeadBucketCommand({
                 Bucket: bucket,
             }));
@@ -110,8 +77,6 @@ describe('S3 Integration Tests', () => {
 
     describe('Upload and Download', () => {
         it('should upload and download text content', async () => {
-            if (!hasS3Credentials()) return;
-
             const key = trackKey(`${testPrefix}/test-text.txt`);
             const content = 'Hello, S3 Integration Test!';
 
@@ -133,8 +98,6 @@ describe('S3 Integration Tests', () => {
         });
 
         it('should upload and download binary content', async () => {
-            if (!hasS3Credentials()) return;
-
             const key = trackKey(`${testPrefix}/test-binary.bin`);
             const content = new Uint8Array([0, 1, 2, 255, 128, 64, 32, 16, 8, 4]);
 
@@ -154,8 +117,6 @@ describe('S3 Integration Tests', () => {
         });
 
         it('should handle large files (100KB)', async () => {
-            if (!hasS3Credentials()) return;
-
             const key = trackKey(`${testPrefix}/test-large.bin`);
             const content = new Uint8Array(100 * 1024);
             for (let i = 0; i < content.length; i++) {
@@ -178,8 +139,6 @@ describe('S3 Integration Tests', () => {
         });
 
         it('should handle Unicode content', async () => {
-            if (!hasS3Credentials()) return;
-
             const key = trackKey(`${testPrefix}/test-unicode.md`);
             const content = '# 日本語テスト\n\nこんにちは世界 🌍';
 
@@ -201,8 +160,6 @@ describe('S3 Integration Tests', () => {
 
     describe('List Objects', () => {
         it('should list objects under a prefix', async () => {
-            if (!hasS3Credentials()) return;
-
             const listPrefix = `${testPrefix}/list-test`;
 
             // Create test files
@@ -234,8 +191,6 @@ describe('S3 Integration Tests', () => {
         });
 
         it('should return empty for non-existent prefix', async () => {
-            if (!hasS3Credentials()) return;
-
             const response = await client.send(new ListObjectsV2Command({
                 Bucket: bucket,
                 Prefix: `${testPrefix}/non-existent-${Date.now()}`,
@@ -247,8 +202,6 @@ describe('S3 Integration Tests', () => {
 
     describe('Delete Operations', () => {
         it('should delete a single file', async () => {
-            if (!hasS3Credentials()) return;
-
             const key = `${testPrefix}/delete-single.txt`;
 
             // Create
@@ -274,8 +227,6 @@ describe('S3 Integration Tests', () => {
         });
 
         it('should delete multiple files', async () => {
-            if (!hasS3Credentials()) return;
-
             const keys = [
                 `${testPrefix}/batch-delete/file1.txt`,
                 `${testPrefix}/batch-delete/file2.txt`,

--- a/tests/storage/S3Provider.test.ts
+++ b/tests/storage/S3Provider.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for S3Provider request shaping.
  */
 
-import { ListObjectsV2Command, PutObjectCommand } from '@aws-sdk/client-s3';
+import { HeadObjectCommand, ListObjectsV2Command, PutObjectCommand } from '@aws-sdk/client-s3';
 import { S3Provider } from '../../src/storage/S3Provider';
 import { S3SyncBackupSettings } from '../../src/types';
 
@@ -63,6 +63,92 @@ describe('S3Provider', () => {
 
 		const command = send.mock.calls[0][0] as PutObjectCommand;
 		expect(command.input.IfMatch).toBe('"abc123"');
+	});
+
+	/**
+	 * Backblaze B2 does not implement conditional PutObject, so
+	 * `providerSupportsConditionalWrites('b2')` is false and uploadFile must
+	 * emulate the guard with a HeadObject pre-check, then upload WITHOUT the
+	 * If-Match / If-None-Match headers. These tests pin that contract with a
+	 * mocked client (the real behaviour is also covered by the B2 provider
+	 * integration matrix).
+	 */
+	describe('conditional-write emulation (providers without native support)', () => {
+		function b2Settings(): S3SyncBackupSettings {
+			return createSettings({ provider: 'b2', endpoint: 'https://s3.us-west-004.backblazeb2.com' });
+		}
+
+		it('create-only (If-None-Match: *) uploads without the header when the object is absent', async () => {
+			const provider = new S3Provider(b2Settings());
+			const send = jest.fn().mockImplementation((cmd) => {
+				if (cmd instanceof HeadObjectCommand) {
+					return Promise.reject({ name: 'NotFound' }); // object absent
+				}
+				return Promise.resolve({ ETag: '"created"' });
+			});
+			(provider as unknown as { client: { send: typeof send } }).client = { send };
+
+			const etag = await provider.uploadFile('vault/new.md', 'hello', { ifNoneMatch: '*' });
+
+			// First a HeadObject pre-check, then a PutObject with NO conditional headers.
+			expect(send.mock.calls[0][0]).toBeInstanceOf(HeadObjectCommand);
+			const put = send.mock.calls[1][0] as PutObjectCommand;
+			expect(put).toBeInstanceOf(PutObjectCommand);
+			expect(put.input.IfNoneMatch).toBeUndefined();
+			expect(put.input.IfMatch).toBeUndefined();
+			expect(etag).toBe('created');
+		});
+
+		it('create-only (If-None-Match: *) throws PreconditionFailed when the object already exists', async () => {
+			const provider = new S3Provider(b2Settings());
+			const send = jest.fn().mockImplementation((cmd) => {
+				if (cmd instanceof HeadObjectCommand) {
+					return Promise.resolve({ ETag: '"exists"', ContentLength: 1, LastModified: new Date(0) });
+				}
+				return Promise.resolve({ ETag: '"should-not-happen"' });
+			});
+			(provider as unknown as { client: { send: typeof send } }).client = { send };
+
+			await expect(
+				provider.uploadFile('vault/exists.md', 'hello', { ifNoneMatch: '*' }),
+			).rejects.toMatchObject({ name: 'PreconditionFailed' });
+
+			// The PutObject must never be sent once the precondition fails.
+			expect(send.mock.calls.some(([cmd]) => cmd instanceof PutObjectCommand)).toBe(false);
+		});
+
+		it('update-only (If-Match) uploads without the header when the remote ETag matches', async () => {
+			const provider = new S3Provider(b2Settings());
+			const send = jest.fn().mockImplementation((cmd) => {
+				if (cmd instanceof HeadObjectCommand) {
+					return Promise.resolve({ ETag: '"abc123"', ContentLength: 1, LastModified: new Date(0) });
+				}
+				return Promise.resolve({ ETag: '"updated"' });
+			});
+			(provider as unknown as { client: { send: typeof send } }).client = { send };
+
+			const etag = await provider.uploadFile('vault/update.md', 'hello', { ifMatch: 'abc123' });
+
+			const put = send.mock.calls[1][0] as PutObjectCommand;
+			expect(put.input.IfMatch).toBeUndefined();
+			expect(etag).toBe('updated');
+		});
+
+		it('update-only (If-Match) throws PreconditionFailed when the remote ETag differs', async () => {
+			const provider = new S3Provider(b2Settings());
+			const send = jest.fn().mockImplementation((cmd) => {
+				if (cmd instanceof HeadObjectCommand) {
+					return Promise.resolve({ ETag: '"different"', ContentLength: 1, LastModified: new Date(0) });
+				}
+				return Promise.resolve({ ETag: '"should-not-happen"' });
+			});
+			(provider as unknown as { client: { send: typeof send } }).client = { send };
+
+			await expect(
+				provider.uploadFile('vault/update.md', 'hello', { ifMatch: 'abc123' }),
+			).rejects.toMatchObject({ name: 'PreconditionFailed' });
+			expect(send.mock.calls.some(([cmd]) => cmd instanceof PutObjectCommand)).toBe(false);
+		});
 	});
 
 	describe('downloadFileAsTextWithEtag', () => {

--- a/tests/sync/SyncWorkflow.integration.test.ts
+++ b/tests/sync/SyncWorkflow.integration.test.ts
@@ -20,24 +20,21 @@ import {
     ListObjectsV2Command,
 } from '@aws-sdk/client-s3';
 import {
+    TestProvider,
     createTestS3Client,
-    hasS3Credentials,
     getS3Config,
     getTestPrefix,
+    describeEachProvider,
 } from '../helpers/s3-test-utils';
 
-describe('Sync Workflow Integration Tests', () => {
+describeEachProvider()('Sync Workflow Integration Tests [$name]', (provider: TestProvider) => {
     let client: S3Client;
     let bucket: string;
     let syncPrefix: string;
 
     beforeAll(() => {
-        if (!hasS3Credentials()) {
-            console.warn('⚠️ S3 credentials not configured, skipping integration tests');
-            return;
-        }
-        client = createTestS3Client();
-        bucket = getS3Config().bucket;
+        client = createTestS3Client(provider);
+        bucket = getS3Config(provider).bucket;
         syncPrefix = getTestPrefix('sync');
     });
 
@@ -70,8 +67,6 @@ describe('Sync Workflow Integration Tests', () => {
          * Verifies files are stored at correct paths under syncPrefix
          */
         it('should store files at correct sync prefix path', async () => {
-            if (!hasS3Credentials()) return;
-
             const localPath = 'Notes/daily/2024-01-01.md';
             const s3Key = `${syncPrefix}/${localPath}`;
             const content = '# Daily Note\n\nThis is a test note.';
@@ -95,8 +90,6 @@ describe('Sync Workflow Integration Tests', () => {
          * Verifies nested folder structure is maintained
          */
         it('should maintain nested folder structure', async () => {
-            if (!hasS3Credentials()) return;
-
             const files = [
                 { path: 'Notes/project-a/readme.md', content: '# Project A' },
                 { path: 'Notes/project-a/tasks.md', content: '# Tasks' },
@@ -123,8 +116,6 @@ describe('Sync Workflow Integration Tests', () => {
          * Verifies sync metadata folder structure
          */
         it('should support sync metadata structure', async () => {
-            if (!hasS3Credentials()) return;
-
             const metadataPrefix = `${syncPrefix}/.obsidian-s3-sync`;
 
             // Journal file
@@ -156,8 +147,6 @@ describe('Sync Workflow Integration Tests', () => {
 
     describe('Upload Workflow', () => {
         it('should complete upload workflow: create → verify → content match', async () => {
-            if (!hasS3Credentials()) return;
-
             const localPath = 'workflow-test/upload-test.md';
             const s3Key = `${syncPrefix}/${localPath}`;
             const content = '# Upload Test\n\n' + new Date().toISOString();
@@ -188,8 +177,6 @@ describe('Sync Workflow Integration Tests', () => {
 
     describe('Conflict Simulation', () => {
         it('should support conflict file naming convention', async () => {
-            if (!hasS3Credentials()) return;
-
             const basePath = 'conflict-test/document.md';
             const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
 


### PR DESCRIPTION
Fixes #78. Linear: CLO-10.

## Problem

Syncing to **Backblaze B2** failed on upload with `A header you provided implies functionality that is not implemented`, while "Test connection" succeeded and no files uploaded.

## Root causes (two — the obvious one wasn't the blocker)

Building a real per-provider test suite surfaced **two** distinct S3-compatibility issues:

1. **Conditional writes — the confirmed blocker.** The sync engine sends `If-None-Match` / `If-Match` on *every* upload (optimistic concurrency). B2's S3 API does **not** implement conditional `PutObject` → `NotImplemented`. "Test connection" passed because it uses bodyless `HeadBucket`.
2. **Default SDK checksums — defensive.** Since `@aws-sdk/client-s3` v3.729.0 the client defaults `requestChecksumCalculation` to `WHEN_SUPPORTED`, attaching `x-amz-checksum-*` headers AWS documents some S3-compatible providers reject. (Testing showed B2 `us-east-005` actually *accepts* CRC32, so it wasn't the blocker there — but it's the correct portable default.)

## Changes

- **`fix`/`feat`(storage):** emulate conditional writes via a `HeadObject` pre-check for providers where `providerSupportsConditionalWrites()` is `false` (B2), throwing the same `PreconditionFailed` then uploading without the unsupported header — sync engine unchanged, small TOCTOU window backstopped by the planner's three-way reconciliation. Pin checksum knobs to `WHEN_REQUIRED`. Add a **first-class Backblaze B2 provider** (type, endpoint/path-style/validation switches, settings UI endpoint + region hints).
- **`test`(storage):** provider-parameterized real-S3 suite — `TEST_PROVIDERS` registry with per-provider env prefixes (`CF_`/`BB_`), `describeEachProvider()`, a test client routed through the production config, a new `ProviderCompatibility` matrix, and the existing integration + e2e suites run per provider. Unit coverage for the capability flag + emulation.
- **`docs` / `ci`:** README, CONTRIBUTING, AGENTS updated; `.env.sample` + `pr-checks.yml` moved to the per-provider `CF_`/`BB_` scheme.

## Verification

Verified green against **real Cloudflare R2 and Backblaze B2**:

| Suite | Result |
|---|---|
| Lint / build (tsc + esbuild) | ✅ |
| Unit | ✅ 594 |
| Integration (CF + BB) | ✅ 60 |
| E2E (CF + BB) | ✅ 60 |

Also confirmed by test: B2 accepts batch `DeleteObjects` (no MD5 fallback needed).

## Follow-ups

- ⚠️ **Add `CF_*` and `BB_*` repository secrets** in GitHub so CI runs the integration/e2e matrix (steps skip until at least one `*_URL` secret is set).
- Base branch is **`main`** (the active mainline); `master` appears stale.
- Future providers (AWS S3, RustFS) can be added by appending to `TEST_PROVIDERS` + `.env.sample`.
